### PR TITLE
Tweaks for reader and responsive

### DIFF
--- a/src/js/components/Header/index.svelte
+++ b/src/js/components/Header/index.svelte
@@ -21,10 +21,13 @@
   //   searchFormDisplayed = !searchFormDisplayed;
   // }
 
-  $: searchFormDisplayed = ( searchState != 'none' );
-  $: console.log("AHOY search_state", searchState, searchFormDisplayed);
+  // let searchOpenToggle = ( searchState == 'default' );
 
-  let searchOpenToggle;
+  $: searchOpenToggle = ( searchState == 'default' );
+  $: searchFormDisplayed = ( searchState == 'default' );
+  $: console.log("AHOY search_state", searchState, searchOpenToggle, searchFormDisplayed);
+  $: console.log("AHOY searchOpenToggle changed", searchOpenToggle);
+
 </script>
 
 <div>

--- a/src/js/components/Modal/index.svelte
+++ b/src/js/components/Modal/index.svelte
@@ -42,7 +42,7 @@
   <link rel="stylesheet" href="https://unpkg.com/open-props" />
 </svelte:head>
 
-<dialog bind:this={dialog}>
+<dialog bind:this={dialog} inert={!isOpen} aria-hidden={!isOpen}>
   <div class="modal show" aria-labelledby="{id}-label" style="display: block;">
     <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
       <div class="modal-content" style:height={height != 'auto' && height}>

--- a/src/js/designs/TwoColumnLayout/index.svelte
+++ b/src/js/designs/TwoColumnLayout/index.svelte
@@ -1,9 +1,19 @@
 <script>
+
+  import { onMount } from 'svelte';
+
   import ResultsList from '../ResultsList';
   import ResultsPagination from '../ResultsPagination';
   import ResultsToolbar from '../ResultsToolbar';
 
   export let enableBorder = false;
+
+  let btnToggleFilters;
+  function toggleExpandedFilters() {
+    let isExpanded = ! ( btnToggleFilters.getAttribute('aria-expanded') == 'true' );
+    btnToggleFilters.setAttribute('aria-expanded', isExpanded);
+  }
+
 </script>
 
 <style lang="scss">
@@ -48,7 +58,7 @@
   .twocol-side {
     display: grid;
     flex-grow: 1;
-    gap: 1.875rem;
+    gap: 1rem;
 
     @media (min-width: 64em) {
       flex-shrink: 0;
@@ -73,14 +83,52 @@
     
   }
  
+  #action-toggle-filters {
+    &[aria-expanded="false"] .is-expanded {
+      display: none;
+    }
+
+    &:is([aria-expanded="true"]) .not-expanded {
+      display: none;
+    }
+
+    &[aria-expanded="false"] ~ * {
+      display: none !important;
+    }
+    
+    @media (min-width: 54em) {
+      display: none;
+
+      & ~ * {
+        display: initial !important;
+      }
+    }
+  } 
 </style>
 
 <main class="main">
   <div class="twocol" class:border={enableBorder}>
-    <div class="twocol-side bg-primary">
-      <div>
-        <slot name="side">.twocol-side</slot>
-      </div>
+    <div class="twocol-side">
+      <slot name="side">
+        <!-- this HTML without the svelte properties is handled -->
+        <!-- by main.js and apps.scss -->
+        <button 
+          id="action-toggle-filters" 
+          class="btn btn-outline-primary" 
+          aria-expanded="false"
+          bind:this={btnToggleFilters}
+          on:click={toggleExpandedFilters}>
+          <span>
+            <span class="not-expanded">Show</span>
+            <span class="is-expanded">Hide</span>
+            Search Filters
+          </span>
+        </button>
+        <h2>This are sidebar items</h2>
+        <div class="alert alert-block alert-info">
+          <p>This is a filter.</p>
+        </div>
+      </slot>
     </div>
     <div class="twocol-main ">
       <div class="mainplain w-auto position-relative">

--- a/src/js/designs/TwoColumnLayout/index.svelte
+++ b/src/js/designs/TwoColumnLayout/index.svelte
@@ -99,7 +99,7 @@
     @media (min-width: 54em) {
       display: none;
 
-      & ~ * {
+      &[aria-expanded] ~ * {
         display: initial !important;
       }
     }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -103,4 +103,12 @@ document.querySelectorAll('[data-hathi-trigger]').forEach((el) => {
   });
 });
 
+let btnToggleFilters = document.querySelector('#action-toggle-filters');
+if ( btnToggleFilters ) {
+  btnToggleFilters.addEventListener('click', (event) => {
+    let isExpanded = ! ( btnToggleFilters.getAttribute('aria-expanded') == 'true' );
+    btnToggleFilters.setAttribute('aria-expanded', isExpanded );
+  })
+}
+
 export default apps;

--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -122,7 +122,7 @@ html, body {
     @media (min-width: 54em) {
       display: none;
 
-      & ~ * {
+      &[aria-expanded] ~ * {
         display: initial !important;
       }
     }

--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -82,7 +82,7 @@ html, body {
     // gap: 1.875rem;
     gap: 1rem;
 
-    @media (min-width: 64em) {
+    @media (min-width: 54em) {
       flex-shrink: 0;
       flex-basis: 18.75rem;
       // gap: 3rem;
@@ -106,6 +106,28 @@ html, body {
     
   }
 
+  #action-toggle-filters {
+    &[aria-expanded="false"] .is-expanded {
+      display: none;
+    }
+
+    &[aria-expanded="true"] .not-expanded {
+      display: none;
+    }
+
+    &[aria-expanded="false"] ~ * {
+      display: none !important;
+    }
+    
+    @media (min-width: 54em) {
+      display: none;
+
+      & ~ * {
+        display: initial !important;
+      }
+    }
+  }
+  
   article.record {
       .metadata .grid {
       --bs-gap: 0rem;


### PR DESCRIPTION
- ironing out the search bar toggle state
- have the `dialog` be inert and `aria-hidden="true"` if it's not visible
- add styles to hide filters unless toggled open
- have `main.js` toggle filter visibility

The Designs > Two Column Layout > Narrow story demonstrates the filter toggle.