### PR TITLE
DEV-753 - add data-action=expand-filters support

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -108,9 +108,28 @@ document.querySelectorAll('[data-hathi-trigger]').forEach((el) => {
 let btnToggleFilters = document.querySelector('#action-toggle-filters');
 if ( btnToggleFilters ) {
   btnToggleFilters.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
     let isExpanded = ! ( btnToggleFilters.getAttribute('aria-expanded') == 'true' );
     btnToggleFilters.setAttribute('aria-expanded', isExpanded );
   })
 }
+
+document.querySelectorAll('[data-action="expand-filter"]').forEach((button) => {
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    let isExpanded = ! ( button.getAttribute('aria-expanded') == 'true' );
+    button.setAttribute('aria-expanded', isExpanded);
+    let container = button.closest('.accordion-body');
+    container.querySelector('.filter-list').dataset.expanded = isExpanded;
+    if ( ! isExpanded ) {
+      container.closest('.accordion-item').scrollIntoView({behavior: 'auto'});
+    }
+  })
+})
+
 
 export default apps;

--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -130,6 +130,16 @@ body {
     }
   }
 
+  button[data-action="expand-filter"] {
+    &[aria-expanded='false'] .is-expanded {
+      display: none;
+    }
+
+    &[aria-expanded='true'] .not-expanded {
+      display: none;
+    }
+  }
+
   article.record {
     .metadata .grid {
       --bs-gap: 0rem;


### PR DESCRIPTION
Added support  to `main.js` and `apps.scss`  to look for buttons with `data-action="expand-filter"`, which will handle the the "show all filter" element.

That filter button needs to look like the Smary version of this XSLT snippet --- configuring `span.not-expanded` and `span.is-expanded`. 

```
<button type="button" class="btn btn-sm btn-outline-dark" data-action="expand-filter" aria-expanded="false">
  <span>
    Show 
    <span class="not-expanded">
      <xsl:text> all </xsl:text>
      <xsl:value-of select="$total" />
      <xsl:text> </xsl:text>
    </span>
    <span class="is-expanded"> fewer </span>
    <xsl:value-of select="$filter/@name" />
    <xsl:text> Filters</xsl:text>
  </span>
</button>
```