### PR TITLE
Firebird task: feedback form as modal for header

### DIFF
--- a/src/js/components/FeedbackFormModal/FeedbackFormModal.stories.js
+++ b/src/js/components/FeedbackFormModal/FeedbackFormModal.stories.js
@@ -1,0 +1,12 @@
+import FeedbackFormModal from './index.svelte';
+
+export default {
+  title: 'Feedback Form Modal',
+  component: FeedbackFormModal,
+};
+
+export const Default = {
+  args: {
+    isOpen: true,
+  },
+};

--- a/src/js/components/FeedbackFormModal/index.svelte
+++ b/src/js/components/FeedbackFormModal/index.svelte
@@ -1,0 +1,36 @@
+<script>
+  import { onMount } from 'svelte';
+  import Modal from '../Modal';
+  import FeedbackFormBasic from '../FeedbackFormBasic';
+  let modal;
+  export let isOpen = false;
+
+  export const show = function () {
+    modal.show();
+  };
+
+  export const hide = function () {
+    modal.hide();
+  };
+  onMount(() => {
+    if (isOpen && modal) {
+      modal.show();
+    }
+  });
+
+  $: if (modal && isOpen) {
+    show();
+  }
+  $: if (modal && !isOpen) {
+    hide();
+  }
+</script>
+
+<div>
+  <Modal bind:this={modal} scrollable>
+    <svelte:fragment slot="modal-title">Questions?</svelte:fragment>
+    <svelte:fragment slot="modal-body">
+      <FeedbackFormBasic />
+    </svelte:fragment>
+  </Modal>
+</div>

--- a/src/js/components/FeedbackFormModal/index.svelte
+++ b/src/js/components/FeedbackFormModal/index.svelte
@@ -38,6 +38,7 @@
       <svelte:fragment slot="modal-body">
         <FeedbackFormCatalog />
       </svelte:fragment>
+      <svelte:fragment slot="modal-footer" />
     </Modal>
   {:else if form == 'content'}
     <Modal bind:this={modal} scrollable>
@@ -47,6 +48,7 @@
       <svelte:fragment slot="modal-body">
         <FeedbackFormContent />
       </svelte:fragment>
+      <svelte:fragment slot="modal-footer" />
     </Modal>
   {:else}
     <Modal bind:this={modal} scrollable>
@@ -54,6 +56,7 @@
       <svelte:fragment slot="modal-body">
         <FeedbackFormBasic />
       </svelte:fragment>
+      <svelte:fragment slot="modal-footer" />
     </Modal>
   {/if}
 </div>

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -12,7 +12,7 @@
   let modal;
   let feedbackModal;
   let form = 'basic';
-  let location = '';
+  let location = document.documentElement.dataset.app;
 
   let notificationsModal;
   let notificationsManager = new NotificationsManager({
@@ -45,10 +45,9 @@
   }
 
   function openFeedback() {
-    // ask Roger how to best identify which domain
-    if (location == 'catalogRecord') {
+    if (location == 'catalog') {
       form == 'catalog';
-    } else if (location == 'pageTurner') {
+    } else if (location == 'pt') {
       form == 'content';
     }
     feedbackModal.show();
@@ -340,6 +339,7 @@
                 <a
                   href="#"
                   class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
+                  on:click|preventDefault={openFeedback}
                 >
                   <span>Report a Problem</span>
                   <i class="fa-solid fa-bug" />

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -45,10 +45,10 @@
   }
 
   function openFeedback() {
-    if (location == 'catalog') {
-      form == 'catalog';
-    } else if (location == 'pt') {
-      form == 'content';
+    if (location === 'catalog') {
+      form = 'catalog';
+    } else if (location === 'pt') {
+      form = 'content';
     }
     feedbackModal.show();
   }
@@ -329,7 +329,7 @@
                 <a
                   href="#"
                   class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                  on:click|preventDefault={openFeedback}
+                  on:click|preventDefault={feedbackModal.show()}
                 >
                   <span>Ask a Question</span>
                   <i class="fa-regular fa-circle-question" />


### PR DESCRIPTION
This is basic/MVP, definitely needs more dynamic behavior when we have time to add.

Getting location from `data-app` attribute on `<html>` element. If catalog, "Report a bug" link shows the catalog quality correction form. If pt, the same link shows content correction form. Anywhere else, "report a bug" will show the basic/general "Questions?" form. "Ask a question" gives the basic/general form regardless of location.

Could use more nuance! I'd like to continue work on this, but we'll see what we have time for in the end.