### PR TITLE
DEV-767-768-769-771-777 - a basket of fixes

### DIFF
--- a/src/js/components/ResultsToolbar/index.svelte
+++ b/src/js/components/ResultsToolbar/index.svelte
@@ -32,8 +32,8 @@
     sortOptions: [
       {value: 'title_a', label: 'Title A-Z'},
       {value: 'title_d', label: 'Title Z-A'},
-      {value: 'author_a', label: 'Author A-Z'},
-      {value: 'author_d', label: 'Author Z-A'},
+      {value: 'auth_a', label: 'Author A-Z'},
+      {value: 'auth_d', label: 'Author Z-A'},
       {value: 'date_d', label: 'Date (newest first)'},
       {value: 'date_a', label: 'Date (oldest first)'},
     ]

--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -156,7 +156,7 @@
               <option value="title">Title</option>
               <option value="author">Author</option>
               <option value="subject">Subject</option>
-              <option value="isbn">ISBN/ISSN</option>
+              <option value="isn">ISBN/ISSN</option>
               <option value="publisher">Publisher</option>
               <option value="seriestitle">Series Title</option>
             </select>

--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -92,7 +92,7 @@
         case '/Record':
           _searchtypeValue = searchParams.get('searchtype') || 'all';
           _selectValue = 'library';
-          _inputValue = searchParams.get('lookfor');
+          _inputValue = searchParams.get('lookfor') || searchParams.get('lookfor[]') || '';
           break;
         default:
           _searchtypeValue = 'everything';


### PR DESCRIPTION
DEV-767: better parsing of `location.search` to fill search bar

DEV-768: search for `isn` instead of `isbn`

DEV-769 - added `isFullText` variable, which defaults to `true` but is modified based  on `location.search` parameters

DEV-771 - changes the message baed on `isFullText`

DEV-777 - update results toolbar with the correct `mb` sort parameters