### PR TITLE
DEV-772-776 + searching full text index

### DIFF
--- a/src/js/components/AcceptableUseBanner/index.svelte
+++ b/src/js/components/AcceptableUseBanner/index.svelte
@@ -5,7 +5,7 @@
   let xtracking = JSON.parse(cookieJar.getItem('HT.x') || '{}');
 
   const key = 'aup-notice';
-  let isVisible = xtracking[key] != true;
+  let isVisible = HT.login_status.logged_in && xtracking[key] != true;
 
   function confirm() {
     let expires = new Date();

--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -514,7 +514,7 @@
       .form-select {
         border: none;
         border-right: 0.5px solid var(--color-neutral-500);
-        padding: 0.625em 0.75em;
+        padding: 0.625em 2.25rem 0.626em 0.75em;
         width: 100%;
         border-radius: 0.375rem;
         margin-left: 0;

--- a/src/js/components/ResultsPagination/index.svelte
+++ b/src/js/components/ResultsPagination/index.svelte
@@ -19,7 +19,10 @@
   }
 </script>
 
-<nav aria-label="Result navigation" class:sticky-bottom={stickyBottom} class="d-flex flex-column align-items-start justify-content-between flex-sm-row align-items-sm-center gap-3">
+<nav 
+  aria-label="Result navigation" 
+  class:nav-sticky-bottom={stickyBottom} 
+  class="d-flex flex-column align-items-start justify-content-between flex-sm-row align-items-sm-center gap-3 rounded">
   <div>
     <ul class="list-unstyled d-flex gap-2 m-0">
       <li>
@@ -54,16 +57,18 @@
   </form>
 </nav>
 
-<style>
-  .sticky-bottom {
-    position: sticky;
-    padding: 1rem;
-    padding-bottom: 1rem;
-    bottom: 0;
-    background-color: #fff;
-    /* box-shadow: 0px -0.5rem 0.5rem -0.5rem rgba(0,0,0,0.1); */
-    box-shadow: 4px 8px 25px  rgba(0, 0, 0, 0.55);
-    margin-left: -0.5rem;
-    margin-right: -0.5rem;
+<style lang="scss">
+  @media (min-width: 600px) and (min-height: 600px) {
+    .nav-sticky-bottom {
+      position: sticky;
+      padding: 0.5rem;
+      bottom: 0.5rem;
+      background-color: #fff;
+      /* box-shadow: 0px -0.5rem 0.5rem -0.5rem rgba(0,0,0,0.1); */
+      box-shadow: 4px 8px 25px  rgba(0, 0, 0, 0.55);
+      margin-left: -0.5rem;
+      margin-right: -0.5rem;
+      z-index: 5;
+    }
   }
 </style>

--- a/src/js/components/ResultsToolbar/index.svelte
+++ b/src/js/components/ResultsToolbar/index.svelte
@@ -114,23 +114,19 @@
   <span id="results-summary">
     {format(firstRecordNumber)} to {format(lastRecordNumber)} of {format(totalRecords)} {label}
   </span>
-  <div class="d-flex flex-row align-items-start gap-3 xxflex-wrap justify-content-end">
+  <div class="d-flex flex-row align-items-start gap-3 flex-wrap flex-sm-nowrap flex-justify-content-end">
     {#if sortOptions !== false}
-    <div class="row flex-nowrap" style="--bs-gutter-x: 0.5rem">
-      <div class="col-auto">
-        <label class="col-form-label fw-normal" for="sort">Sort by</label>
-      </div>
-      <div class="col-auto">
-        <select class="form-select" id="sort" name="sort" size="1" bind:value={currentSortOption} on:change={onSubmit}>
-          {#each sortOptions as sortOption}
-            <option value={sortOption.value} selected={sortOption.value == currentSortOption}>{sortOption.label}</option>
-          {/each}
-        </select>
-      </div>
+    <div class="d-flex flex-nowrap gap-1">
+      <label class="col-form-label fw-normal text-nowrap" for="sort">Sort by</label>
+      <select class="form-select w-auto" id="sort" name="sort" size="1" bind:value={currentSortOption} on:change={onSubmit}>
+        {#each sortOptions as sortOption}
+          <option value={sortOption.value} selected={sortOption.value == currentSortOption}>{sortOption.label}</option>
+        {/each}
+      </select>
     </div>
     {/if}
     {#if target == 'mb.listcs'}
-      <button class="btn btn-secondary" on:click={openModal}>New List</button>
+      <button type="button" class="btn btn-secondary text-nowrap" on:click={openModal}>New List</button>
     {/if}
     <!-- <div class="row flex-nowrap" style="--bs-gutter-x: 0.5rem">
       <div class="col-auto">


### PR DESCRIPTION
DEV-772 - updated the pagination to be less heavy and reflect our rounded-shadow motifs; it also is not sticky when the viewport is <= 600px in either dimension. (To be tuned later.)

Setting that seemed to fix the AUP? Or something.

DEV-776: adjusted the padding on the advanced search selects so they didn't overlap the caret on narrow viewports.

While I was there, refined the `onMount` behavior to fill in more fields, and added the option to use the full text index.