### PR TITLE
for pt: add compact header + search toggle

### DIFF
--- a/src/js/components/Header/index.svelte
+++ b/src/js/components/Header/index.svelte
@@ -6,6 +6,8 @@
   import SearchBar from '../SearchBar';
 
   export let searchState = 'default';
+  export let compact = false;
+
   // let searchFormDisplayed = search_state == 'default';
   // let searchFormDisplayed = true;
 
@@ -13,7 +15,7 @@
     if (searchState == 'default') {
       return true;
     } else if (searchState == 'toggle') {
-      return searchFormDisplayed;
+      return searchOpenToggle;
     }
     return false;
   }
@@ -31,7 +33,7 @@
 </script>
 
 <div>
-  <Navbar bind:searchOpen={searchOpenToggle} {searchState}/>
+  <Navbar bind:searchOpen={searchOpenToggle} {searchState} {compact}/>
   {#if searchOpenToggle}
     <div
       out:slide={{ easing: sineOut, duration: 150 }}
@@ -40,7 +42,7 @@
       class:show={searchOpenToggle}
       id="siteSearchDropdown"
     >
-      {#if searchFormDisplayed}
+      {#if displaySearchForm()}
       <SearchBar />
       {/if}
     </div>

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -23,6 +23,7 @@
   export let hasNotification = false;
   export let searchOpen = true;
   export let searchState;
+  export let compact = false;
 
   const switchableRoles = ['enhancedTextProxy', 'totalAccess'];
   const switchableRolesLabels = {};
@@ -31,6 +32,7 @@
 
   function toggleSearch() {
     searchOpen = !searchOpen;
+    console.log("AHOY searchOpen", searchOpen);
   }
 
   function openLogin() {
@@ -88,7 +90,7 @@
 <FeedbackFormModal {form} bind:this={feedbackModal} />
 <nav class="navbar navbar-expand-xl bg-white">
   <div class="container-fluid">
-    <div class="ht-logo">
+    <div class="ht-logo" class:compact={compact}>
       <!-- <img src="../assets/HT-logo-mobile-nav.svg" alt="HathiTrust" class="" /> -->
       <svg
         width="180"
@@ -495,6 +497,12 @@
   }
   .navbar .ht-logo {
     padding-left: 1rem;
+
+    &.compact {
+      padding-top: 0.25rem;
+      padding-bottom: 0.25rem;
+    }
+
     @media (min-width: 1200px) {
       padding-right: 2.5rem;
     }


### PR DESCRIPTION
Definitely adding support for a `compact`  header.

Slightly perplexed about the search form toggling, because this wasn't working in `pt` but seems to be working fine in `preview.www`.  Plan to double check the Netlify PR instance with preview.www.