### PR TITLE
add analytics if ping sends container

### DIFF
--- a/src/js/lib/analytics.js
+++ b/src/js/lib/analytics.js
@@ -1,0 +1,26 @@
+
+export class AnalyticsManager {
+  constructor({ analyticsSettings, is_dev=false }) {
+    this.service = is_dev ? analyticsSettings.dev : analyticsSettings.service;
+    this.container = analyticsSettings.container;
+  }
+
+  configure() {
+    if ( ! this.service ) { return ; }
+
+    const _mtm = window._mtm = window._mtm || [];
+    const _paq = window._paq = window._paq || [];
+    _mtm.push({ 'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start' });
+
+    let customUrl;
+    if ( customUrl = document.documentElement.dataset.analyticsReportUrl ) {
+      // application has provided an analytics url
+      _paq.push(['setCustomUrl', customUrl]);
+    }
+
+    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.async = true; g.src = `https://${this.service}/js/container_${this.container}.js`; s.parentNode.insertBefore(g, s);   
+  }
+}
+
+export default AnalyticsManager;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,7 @@
 // Import our custom CSS
 import '../scss/styles.scss';
 import { setupHTEnv } from './lib/utils';
+import { AnalyticsManager } from './lib/analytics';
 
 // Import all of Bootstrap's JS
 // these are made available globally
@@ -81,6 +82,7 @@ HT.postPingCallback = function () {
   setTimeout(() => {
     document.body.dataset.initialized = true;
   });
+  (new AnalyticsManager(HT)).configure();
 };
 
 let script = document.createElement('script');


### PR DESCRIPTION
`ping` will send analytics configuration managed in `/htapps/babel/etc/settings/ping/analytics.json`, and analytics will be configured if there's configuration.