### PR TITLE
Add dialog polyfill for modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@popperjs/core": "^2.11.6",
         "@vitejs/plugin-basic-ssl": "^1.0.1",
         "bootstrap": "^5.2.3",
+        "dialog-polyfill": "^0.5.6",
         "svelte-preprocess": "^5.0.1"
       },
       "devDependencies": {
@@ -6138,6 +6139,11 @@
         "detect": "bin/detect-port.js",
         "detect-port": "bin/detect-port.js"
       }
+    },
+    "node_modules/dialog-polyfill": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
+      "integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w=="
     },
     "node_modules/diff-sequences": {
       "version": "29.4.3",
@@ -16933,6 +16939,11 @@
         "address": "^1.0.1",
         "debug": "4"
       }
+    },
+    "dialog-polyfill": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
+      "integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w=="
     },
     "diff-sequences": {
       "version": "29.4.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@popperjs/core": "^2.11.6",
     "@vitejs/plugin-basic-ssl": "^1.0.1",
     "bootstrap": "^5.2.3",
+    "dialog-polyfill": "^0.5.6",
     "svelte-preprocess": "^5.0.1"
   }
 }

--- a/src/js/components/Modal/index.svelte
+++ b/src/js/components/Modal/index.svelte
@@ -149,6 +149,11 @@
     backdrop-filter: blur(2px);
   }
 
+  :global(dialog + .backdrop) {
+    transition: backdrop-filter 0.25s ease;
+    backdrop-filter: blur(2px);    
+  }
+
   dialog {
     animation: var(--animation-scale-down) forwards;
     animation-timing-function: var(--ease-squish-3);

--- a/src/js/components/Modal/index.svelte
+++ b/src/js/components/Modal/index.svelte
@@ -152,8 +152,16 @@
   :global(dialog + .backdrop) {
     transition: backdrop-filter 0.25s ease;
     backdrop-filter: blur(2px);    
+    position: fixed;
+    top: 0; right: 0; bottom: 0; left: 0;
+    background: rgba(0,0,0,0.1);
   }
 
+  :global(._dialog_overlay) {
+    position: fixed;
+    top: 0; right: 0; bottom: 0; left: 0;
+  }
+ 
   dialog {
     animation: var(--animation-scale-down) forwards;
     animation-timing-function: var(--ease-squish-3);

--- a/src/js/components/Modal/index.svelte
+++ b/src/js/components/Modal/index.svelte
@@ -2,6 +2,8 @@
   import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
 
+  import dialogPolyfill from 'dialog-polyfill';
+
   export let isOpen = false;
   export let id = `id${new Date().getTime()}-${Math.floor(Math.random() * Date.now())}`;
   export let onClose = function () {};
@@ -25,6 +27,7 @@
   };
 
   export const hide = function () {
+    if ( ! dialog.open ) { return ; }
     dialog.close();
     isOpen = false;
     onClose();
@@ -32,6 +35,12 @@
   };
 
   onMount(() => {
+
+    if ( ! globalThis.HTMLDialogElement ) {
+      console.log('-- polyfilling dialog');
+      dialogPolyfill.registerDialog(dialog);
+    }
+
     if (isOpen) {
       openModal();
     }


### PR DESCRIPTION
Adds https://github.com/GoogleChrome/dialog-polyfill and registers it as needed. Annoyingly has to be applied to every `<dialog>` element and has been folded into the Modal component.