### PR TITLE
DEV-925: add ping/switch target when switching roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#macos
+.DS_Store
+**/.DS_Store
+
 # Logs
 logs
 *.log

--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -270,7 +270,6 @@
 
   onMount(() => {
     let params = new URLSearchParams(location.search.replace(/;/g, '&'));
-    let theUrl = window.location.href;
     if (location.pathname == '/Search/Advanced') {
       // catalog
       params.getAll('lookfor[]').forEach((value, idx) => {
@@ -296,7 +295,7 @@
         format = format;
       }
 
-      if (!params.get('ft') && theUrl.includes('?')) {
+      if (!params.get('ft') && window.location.href.includes('?')) {
         isFullView = false;
       }
 

--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -126,7 +126,9 @@
         errors.lookFors = true;
       }
 
-      if (Object.values(pubYear).find((value) => value != '' && value != null)) {
+      if (
+        Object.values(pubYear).find((value) => value != '' && value != null)
+      ) {
         // possibly have pub year
         if (yop == 'before' && pubYear.end) {
           searchParams.set('yop', yop);
@@ -157,7 +159,9 @@
       }
 
       bools.forEach((value, idx) => {
-        if ( idx === 0 ) { return ; }
+        if (idx === 0) {
+          return;
+        }
         if (value && lookFors[idx] && lookFors[idx - 1]) {
           searchParams.append('bool[]', value);
         }
@@ -180,7 +184,7 @@
       searchParams.set('a', 'srchls');
       searchParams.set('adv', 1);
 
-      if ( collid ) {
+      if (collid) {
         searchParams.set('c', collid);
       }
 
@@ -214,7 +218,9 @@
         errors.lookFors = true;
       }
 
-      if (Object.values(pubYear).find((value) => value != '' && value != null)) {
+      if (
+        Object.values(pubYear).find((value) => value != '' && value != null)
+      ) {
         // possibly have pub year
         if (yop == 'before' && pubYear.end) {
           searchParams.set('yop', yop);
@@ -287,6 +293,10 @@
           format.push(value);
         });
         format = format;
+      }
+
+      if (!params.get('ft')) {
+        isFullView = false;
       }
 
       yop = params.get('yop') || 'after';
@@ -364,14 +374,14 @@
 <div class="twocol">
   <div class="twocol-side" id="sidebar">
     {#if collid}
-    <hgroup role="group" aria-roledescription="Heading group">
-    <h1>Advanced Search</h1>
-    <p aria-roledescription="subtitle" class="h2">
-      <a href="/cgi/ls?a=srchls&q1=*&c={collid}">{collectionName}</a>
-    </p>
-    </hgroup>    
+      <hgroup role="group" aria-roledescription="Heading group">
+        <h1>Advanced Search</h1>
+        <p aria-roledescription="subtitle" class="h2">
+          <a href="/cgi/ls?a=srchls&q1=*&c={collid}">{collectionName}</a>
+        </p>
+      </hgroup>
     {:else}
-    <h1>Advanced Search</h1>
+      <h1>Advanced Search</h1>
     {/if}
     <div class="search-details d-flex">
       <span class="search-help"
@@ -427,9 +437,7 @@
                   will match fields containing the phrase
                   <code>"occult fiction"</code>.
                 </dd>
-                <dt>
-                  Using wildcards
-                </dt>
+                <dt>Using wildcards</dt>
                 <dd>
                   Use <code>*</code> or <code>?</code> to search for alternate
                   forms of a word. Use <code>*</code>
@@ -438,13 +446,15 @@
                   <code>optim*</code> will find optimal, optimize or optimum;
                   <code>wom?n</code> will find woman and women. If you would
                   simply like to browse without entering a search term you can
-                  enter <code>*</code> by itself.
-                  Wildcard search is <strong>not</strong> available in 
-                  <strong>Full Text & All Fields</strong> and 
+                  enter <code>*</code> by itself. Wildcard search is
+                  <strong>not</strong>
+                  available in
+                  <strong>Full Text & All Fields</strong> and
                   <strong>Only Full Text</strong> search.
                 </dd>
-                <dd>If you would simply like to browse without entering
-                  a search term you can enter <code>*</code> by itself.
+                <dd>
+                  If you would simply like to browse without entering a search
+                  term you can enter <code>*</code> by itself.
                 </dd>
               </dl>
             </div>
@@ -472,8 +482,8 @@
             <div class="accordion-body">
               <p>
                 Check the <strong>Always use the Full Text Index</strong>
-                option to display search results at the item level 
-                and to be able to add your search results to a collection.
+                option to display search results at the item level and to be able
+                to add your search results to a collection.
               </p>
             </div>
           </div>

--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -270,6 +270,7 @@
 
   onMount(() => {
     let params = new URLSearchParams(location.search.replace(/;/g, '&'));
+    let theUrl = window.location.href;
     if (location.pathname == '/Search/Advanced') {
       // catalog
       params.getAll('lookfor[]').forEach((value, idx) => {
@@ -295,7 +296,7 @@
         format = format;
       }
 
-      if (!params.get('ft')) {
+      if (!params.get('ft') && theUrl.includes('?')) {
         isFullView = false;
       }
 

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -38,7 +38,7 @@
 
   function openLogin() {
     //check viewport size to see if LoginFormModal will fit
-    if ( window.innerHeight <= 670 || $loginStatus.idp_list.length == 0 ) {
+    if (window.innerHeight <= 670 || $loginStatus.idp_list.length == 0) {
       //if not, redirect user
       //calculate login target
       let target = window.location.href;
@@ -46,7 +46,9 @@
         // not a babel app, need to route through ping/pong
         target = HT.get_pong_target(target);
       }
-      window.location.assign(`//${HT.service_domain}/cgi/wayf?target=${encodeURIComponent(target)}`);
+      window.location.assign(
+        `//${HT.service_domain}/cgi/wayf?target=${encodeURIComponent(target)}`
+      );
     } else {
       //else, open LoginFormModal
       modal.show();
@@ -87,10 +89,10 @@
   $: hasSwitchableRoles = checkSwitchableRoles(loggedIn).status;
   $: hasActivatedRole = checkSwitchableRoles(loggedIn).activated;
   $: role = checkSwitchableRoles(loggedIn).label;
-  $: if ( $loginStatus && $loginStatus.notificationData ) {
-      notificationsManager.update($loginStatus.notificationData);
-      hasNotification = notificationsManager.hasNotifications();
-    }
+  $: if ($loginStatus && $loginStatus.notificationData) {
+    notificationsManager.update($loginStatus.notificationData);
+    hasNotification = notificationsManager.hasNotifications();
+  }
 </script>
 
 <FeedbackFormModal {form} bind:this={feedbackModal} />
@@ -408,13 +410,16 @@
                   <li class="px-3">
                     <button
                       class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                      data-disabled="{!hasNotification}"
+                      data-disabled={!hasNotification}
                       disabled={!hasNotification ? true : null}
                       on:click={notificationsModal.show()}
                       ><span class="needs-hover-state"
                         >Notifications {#if hasNotification}({notificationsManager.count()}){/if}</span
                       >
-                      <i class="fa-solid fa-bell fa-fw" class:opacity-25={!hasNotification} />
+                      <i
+                        class="fa-solid fa-bell fa-fw"
+                        class:opacity-25={!hasNotification}
+                      />
                     </button>
                   </li>
                   {#if hasSwitchableRoles}
@@ -426,7 +431,11 @@
                     <li class="px-3">
                       <a
                         class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                        href="//{HT.service_domain}/cgi/ping/switch"
+                        href="//{`${
+                          HT.service_domain
+                        }/cgi/ping/switch?target=${encodeURIComponent(
+                          window.location.href
+                        )}`}"
                         role="button"
                         ><span class="needs-hover-state">
                           {#if hasActivatedRole}
@@ -454,7 +463,11 @@
                   <li class="px-3">
                     <a
                       class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                      href="//{`${HT.service_domain}/cgi/logout?${encodeURIComponent(window.location.href)}`}"
+                      href="//{`${
+                        HT.service_domain
+                      }/cgi/logout?${encodeURIComponent(
+                        window.location.href
+                      )}`}"
                       role="button"
                       ><span class="needs-hover-state">Log Out</span><i
                         class="fa-solid fa-arrow-right-from-bracket fa-fw"


### PR DESCRIPTION
## Problem

When in catalog (or website), if user chooses to switch roles via the navbar login/account button, the user is sent back to the website homepage instead of the page they were on. 

## Fix
 
`/components/Navbar/index.js` (line 434)

```js
 href="//{`${
                          HT.service_domain
                        }/cgi/ping/switch?target=${encodeURIComponent(
                          window.location.href
                        )}`}"
```
I borrowed the code from Roger's logout redirect just below this in the same file.

`babel-local-dev` doesn't have `ping` (or at least mine doesn't), so I tested this on https://dev-3.catalog.hathitrust.org/Search/Home 

## Test it

Conduct search, open catalog record, log in and switch role to CAA-- you should be redirected back to the page you were on.