### PR TITLE
DEV-896: matomo custom page title

### DIFF
--- a/src/js/lib/analytics.js
+++ b/src/js/lib/analytics.js
@@ -25,6 +25,12 @@ export class AnalyticsManager {
       _paq.push(['setCustomUrl', customUrl]);
     }
 
+    let customPageTitle;
+    if ((customPageTitle = document.documentElement.dataset.originalTitle)) {
+      // pt has provided an original title
+      _paq.push(['setDocumentTitle', customPageTitle]);
+    }
+
     var d = document,
       g = d.createElement('script'),
       s = d.getElementsByTagName('script')[0];


### PR DESCRIPTION
I added the javascript [matomo suggests for this type of thing](https://matomo.org/faq/how-to/how-do-i-set-a-custom-page-title-using-the-matomo-javascript-title/) to the firebird analytics file. 

This is staged on dev-3 and you can "test" it on any pageturner item, but the results only show up on testing.matomo. Here's a screenshot from my "visitor profile" showing that the titles used to have seq # in them, and now they don't!

<img width="352" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/bb6baa22-ca22-4478-b3a3-2cce8136c824">
