### PR TITLE
remove font awesome script

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,22 +1,23 @@
 /** @type { import('@storybook/svelte-vite').StorybookConfig } */
 const config = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx|svelte)"],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx|svelte)'],
   addons: [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-interactions",
-    "@storybook/addon-svelte-csf",
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    '@storybook/addon-svelte-csf',
     // "@storybook/preset-scss",
   ],
   framework: {
-    name: "@storybook/svelte-vite",
+    name: '@storybook/svelte-vite',
     options: {},
   },
   features: {
     interactionsDebugger: true,
   },
   docs: {
-    autodocs: "tag",
+    autodocs: 'tag',
   },
+  staticDirs: ['../src/public'],
 };
 export default config;

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,7 +1,3 @@
 <script>
   window.global = window;
 </script>
-<script
-  src="https://kit.fontawesome.com/1c6c3b2b35.js"
-  crossorigin="anonymous"
-></script>


### PR DESCRIPTION
Removed font-awesome script from storybook preview head tag. I also updated the storybook config to set the static asset directory path in case we need that in the future.