### PR TITLE
Winter break message for feedback form

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build-js": "vite build",
     "build": "vite build && storybook build -o dist/storybook && node ./build-redirects.js",
     "test-storybook": "test-storybook",
-    "chromatic": "chromatic --exit-zero-on-changes"
+    "chromatic": "chromatic --exit-zero-on-changes",
+    "babel": "vite build --watch"
   },
   "repository": {
     "type": "git",

--- a/src/js/components/FeedbackFormModal/FeedbackFormModal.stories.js
+++ b/src/js/components/FeedbackFormModal/FeedbackFormModal.stories.js
@@ -8,5 +8,31 @@ export default {
 export const Default = {
   args: {
     isOpen: true,
+    form: 'basic',
+    winterBreak: false,
   },
+};
+
+export const Catalog = {
+  args: {
+    isOpen: true,
+    form: 'catalog',
+    winterBreak: false,
+  },
+};
+
+export const Content = {
+  args: {
+    isOpen: true,
+    form: 'content',
+    winterBreak: false,
+  },
+};
+
+
+export const WinterBreak = {
+  args: {
+    isOpen: true,
+    winterBreak: true
+  } 
 };

--- a/src/js/components/FeedbackFormModal/index.svelte
+++ b/src/js/components/FeedbackFormModal/index.svelte
@@ -28,6 +28,24 @@
   $: if (modal && !isOpen) {
     hide();
   }
+
+  let today = new Date();
+
+  export let winterBreak = false;
+
+  if (
+    (today.getFullYear() == 2023 && today.getMonth() == 11 && today.getDate() >= 22) ||
+    (today.getFullYear() == 2024 && today.getMonth() == 0 && today.getDate() <= 2)
+  ) {
+    // if today is a date in 2023, in the month of december, on or after the 22nd
+    // OR today is a date in 2024, in the month of january, on or before the 2nd
+    winterBreak = true;
+  }
+
+  let message = `<i class="fa-regular fa-snowflake" aria-hidden="true"></i> HathiTrust User Support is out of the office
+            during the United States holidays through January 2nd. The team is still receiving patron messages at
+            <a href="mailto:support@hathitrust.org">support@hathitrust.org</a>, but you should expect a delay in
+            response during this time. Thanks for your patience.`;
 </script>
 
 <div>
@@ -35,6 +53,7 @@
     <Modal bind:this={modal} scrollable>
       <svelte:fragment slot="title">Catalog Quality Correction</svelte:fragment>
       <svelte:fragment slot="body">
+        {#if winterBreak}<p>{@html message}</p>{/if}
         <FeedbackFormCatalog />
       </svelte:fragment>
     </Modal>
@@ -42,6 +61,7 @@
     <Modal bind:this={modal} scrollable>
       <svelte:fragment slot="title">Content Quality Correction</svelte:fragment>
       <svelte:fragment slot="body">
+        {#if winterBreak}<p>{@html message}</p>{/if}
         <FeedbackFormContent />
       </svelte:fragment>
     </Modal>
@@ -49,6 +69,7 @@
     <Modal bind:this={modal} scrollable>
       <svelte:fragment slot="title">Questions?</svelte:fragment>
       <svelte:fragment slot="body">
+        {#if winterBreak}<p>{@html message}</p>{/if}
         <FeedbackFormBasic />
       </svelte:fragment>
     </Modal>
@@ -56,6 +77,7 @@
     <Modal bind:this={modal} scrollable>
       <svelte:fragment slot="title">Questions?</svelte:fragment>
       <svelte:fragment slot="body">
+        {#if winterBreak}<p>{@html message}</p>{/if}
         <FeedbackFormBasic />
       </svelte:fragment>
     </Modal>


### PR DESCRIPTION
## winter break message
I used Roger's [date logic](https://github.com/hathitrust/common/blob/463fb5facb7f6796898373e9c0404910ca3d9f5b/web/alicorn/src/js/components/feedback.js#L60) from alicorn and Val's suggested wording to create a message for the form that will only show between two dates (in this case Dec 22 - Jan 2). I added a few stories to the storybook, too. 

Take a look at the [deploy preview on netlify](https://deploy-preview-55--hathitrust-firebird-common.netlify.app/storybook/?path=/story/feedback-form-modal--winter-break). This links to the Winter Break story, but there is also a `winterBreak` variable on the other versions of the feedback form modal, so you can toggle the message on and off to see what it will look like in each variant of the modal. I deployed this on dev-3, but it's hard to see something that isn't supposed to work until Dec 22.

~In a perfect world, I'd use this moment to refactor this component, but I have a vague memory that getting this to work in a DRY fashion was not worth figuring out at the time.~ I tried to refactor, but then remembered why this doesn't work: svelte slots don't work with conditionals like I want them to in Svelte 3. There's a new feature in Svelte 5 called snippets that should do the trick. It's ugly for now, but it works!

## `vite build --watch`
I also added a script to `package.json` to make it easier to reload firebird files when working in `babel-local-dev`. There's a separate issue with the storybook in `babel-local-dev` that I still need to address, but this is a good first step.