### PR TITLE
update search URLs to use location protocol

### DIFF
--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -67,6 +67,8 @@
     yop: false,
   };
 
+  let protocol = 'https:' == location.protocol ? 'https:' : 'http:';
+
   function saveIndexSelection() {
     console.log('AHOY saveIndexSelection', useFullTextIndex);
     sessionStorage.setItem('useFullTextIndex', useFullTextIndex);
@@ -94,7 +96,7 @@
       }
     }
     if (target == 'catalog') {
-      url = new URL(`https://${HT.catalog_domain}/Search/Home`);
+      url = new URL(`${protocol}//${HT.catalog_domain}/Search/Home`);
       let searchParams = new URLSearchParams();
       searchParams.set('adv', 1);
       if (isFullView) {
@@ -174,7 +176,7 @@
 
       url.search = searchParams.toString();
     } else {
-      url = new URL(`https://${HT.service_domain}/cgi/ls`);
+      url = new URL(`${protocol}//${HT.service_domain}/cgi/ls`);
       let searchParams = new URLSearchParams();
       if (isFullView) {
         searchParams.set('lmt', 'ft');


### PR DESCRIPTION
When working on Advanced Search locally, the search part doesn't actually work thanks to the hard-coded `https` protocol. This update adds a check for the current `location.protocol`, then builds the search URL using `https` if that's the current protocol, otherwise falls back to `http`.

This is up on `dev-3` and looks like it's working. 

- [dev 3 `ls` advanced search](https://dev-3.babel.hathitrust.org/cgi/ls?a=page&page=advanced)
- [dev 3 `catalog` advanced search](https://dev-3.catalog.hathitrust.org/Search/Advanced)

But I'm interested to see if anyone can get my changes working locally with my new babel-local-dev firebird workflow.

Perhaps:
1. in `/babel/firebird-common`, `git fetch` and switch to the `TTO-166` branch
2. `docker compose run node bash` will drop you into a `I have no name!` exec where you can run npm commands
3. `cd /htapps/babel/firebird-common` 
4. `npm run babel` will build your files (and the asset manifest) and watch them for changes you make

if you got an error about missing a file or a package, you might need to `npm i` for good measure (I had this problem today)

I'm interested to see if this works for other people like I think it should. I'm also 100% sure there is a better way to run commands in docker than what I've done here, but it works!

And if you get my changes working locally, hopefully you can do an advanced search 🤞