### PR TITLE
Hide alert banner

### DIFF
--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -28,6 +28,7 @@ body {
 
   hathi-alert-banner {
     grid-area: banner;
+    display: none;
   }
 
   hathi-website-footer {


### PR DESCRIPTION
In the future, the visbility and text of the alert banner should be driven by something external, but this seems like the simplest change to hide it for the time being.