### PR TITLE
DEV-1095: alert banner - add close button and dismissible state

### DIFF
--- a/src/js/components/AlertBanner/AlertBanner.stories.js
+++ b/src/js/components/AlertBanner/AlertBanner.stories.js
@@ -1,4 +1,5 @@
 import AlertBanner from './index.svelte'
+import PingCallbackDecorator from '../../decorators/PingCallbackDecorator';
 
 export default {
     title: 'Alert Banner',
@@ -11,4 +12,10 @@ export const Default = {
       defaultViewport: 'bsLg',
     },
   }, 
+  decorators: [
+    () => ({
+      Component: PingCallbackDecorator,
+      // props: { loggedIn: true },
+    }),
+  ],
 }

--- a/src/js/components/AlertBanner/index.svelte
+++ b/src/js/components/AlertBanner/index.svelte
@@ -8,8 +8,9 @@
       title: 'Outage: Incomplete search results',
       message: 'Users searching within the full text of all volumes will receive incomplete search results.',
       link: 'https://www.hathitrust.org/press-post/outage-incomplete-search-results/',
-      linkText: 'More information',
+      linkText: 'See updates here',
       type: 'warning',
+      //ID should increment with each new alert
       id: 1,
     },
   ];
@@ -111,40 +112,7 @@
       padding: 0rem 1rem;
       justify-content: center;
       align-items: center;
-      // gap: 0.625rem;
-      border-radius: 0.25rem;
       margin-top: 0.25rem;
-      .close-icon {
-        padding: 0.625rem;
-        border-radius: 50%;
-        width: 2rem;
-        height: 2rem;
-        display: block;
-        position: relative;
-        i {
-          color: var(--color-neutral-600);
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          transform: translate(-50%, -50%);
-          transition: opacity 0.25s ease-out;
-        }
-      }
-      .close-icon .icon-default {
-        opacity: 1;
-      }
-      .close-icon .icon-hover {
-        opacity: 0;
-      }
-      .close-icon:hover .icon-default,
-      .close-icon:focus .icon-default {
-        opacity: 0;
-        color: transparent;
-      }
-      .close-icon:hover .icon-hover,
-      .close-icon:focus .icon-hover {
-        opacity: 1;
-      }
     }
   }
   @media (min-width: 48em) {

--- a/src/js/components/AlertBanner/index.svelte
+++ b/src/js/components/AlertBanner/index.svelte
@@ -1,24 +1,65 @@
 <script>
-  export let alertType = 'warning';
+  import { preferencesConsent } from '../../lib/store';
+  let HT = window.HT || {};
+  let cookieJar = HT.cookieJar;
+
+  const alertData = [
+    {
+      title: 'Outage: Incomplete search results',
+      message: 'Users searching within the full text of all volumes will receive incomplete search results.',
+      link: 'https://www.hathitrust.org/press-post/outage-incomplete-search-results/',
+      linkText: 'More information',
+      type: 'warning',
+      id: 1,
+    },
+  ];
+
+  let isVisible = true;
+
+  function closeAlert() {
+    //if user has functional/preference cookies enabled, set a 14-day cookie to remember dismissed preference
+    if ($preferencesConsent === 'true') {
+      let expires = new Date();
+      expires.setDate(expires.getDate() + 14);
+      cookieJar.setItem(`HT-alert-${alertData[0].id}`, 'dismissed', expires, '/', HT.cookies_domain, true);
+      isVisible = false;
+    }
+    //reset focus to the main element once the banner is removed from the DOM
+    if (document.querySelector('main')) {
+      document.querySelector('main').focus();
+    }
+  }
+
+  if (cookieJar.getItem(`HT-alert-${alertData[0].id}`) === 'dismissed') {
+    isVisible = false;
+  }
 </script>
 
-<div
-  class="alert d-flex mx-3 gap-2 {alertType === 'warning'
-    ? 'alert-warning'
-    : alertType === 'danger'
-      ? 'alert-danger'
-      : 'alert-info'}"
-  role="alert"
->
-  <i class="alert-icon fa-solid fa-triangle-exclamation"></i>
-  <div class="d-flex flex-column gap-2 py-3">
-    <p class="alert-heading">Outage: Incomplete search results</p>
-    <p>Users searching within the full text of all volumes will receive incomplete search results.</p>
-    <a class="alert-link" href="https://www.hathitrust.org/press-post/outage-incomplete-search-results/"
-      >More information</a
-    >
-  </div>
-</div>
+{#if isVisible}
+  {#each alertData as alert}
+    <div class="alert alert-dismissible d-flex mx-3 justify-content-between fade show alert-{alert.type}" role="alert">
+      <div class="d-flex gap-2">
+        <i class="alert-icon fa-solid fa-triangle-exclamation"></i>
+        <div class="d-flex flex-column gap-2 py-3">
+          <p class="alert-heading">{alert.title}</p>
+          <p>{alert.message}</p>
+          <a class="alert-link" href={alert.link}>{alert.linkText}</a>
+        </div>
+      </div>
+      <div class="close-wrapper">
+        <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" on:click={closeAlert}>
+          <span class="close-icon">
+            <i class="fa-solid fa-xmark icon-default" aria-hidden="true"></i><span class="fa-sr-only">Close banner</span
+            >
+            <i class="fa-solid fa-circle-xmark fa-2x icon-hover" aria-hidden="true"></i><span class="fa-sr-only"
+              >Close banner</span
+            >
+          </span>
+        </button>
+      </div>
+    </div>
+  {/each}
+{/if}
 
 <style lang="scss">
   .alert-warning {
@@ -35,7 +76,7 @@
     padding: 0;
     border-radius: 0.25rem;
     box-shadow: 0px 4px 8px 0px rgba(25, 11, 1, 0.04);
-    i {
+    i.alert-icon {
       color: var(--bs-alert-border-color);
       display: flex;
       width: 1.5rem;
@@ -57,6 +98,57 @@
       font-weight: 500;
       color: var(--bs-alert-color);
     }
+    .close-wrapper {
+      display: flex;
+      align-items: flex-start;
+    }
+    button {
+      background: var(--bs-alert-bg);
+      border: none;
+      display: flex;
+      width: 2.75rem;
+      height: 2.75rem;
+      padding: 0rem 1rem;
+      justify-content: center;
+      align-items: center;
+      // gap: 0.625rem;
+      border-radius: 0.25rem;
+      margin-top: 0.25rem;
+      .close-icon {
+        padding: 0.625rem;
+        border-radius: 50%;
+        width: 2rem;
+        height: 2rem;
+        display: block;
+        position: relative;
+        i {
+          color: var(--color-neutral-600);
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          transition: opacity 0.25s ease-out;
+        }
+      }
+      .close-icon .icon-default {
+        opacity: 1;
+      }
+      .close-icon .icon-hover {
+        opacity: 0;
+      }
+      .close-icon:hover .icon-default,
+      .close-icon:focus .icon-default {
+        opacity: 0;
+        color: transparent;
+      }
+      .close-icon:hover .icon-hover,
+      .close-icon:focus .icon-hover {
+        opacity: 1;
+      }
+    }
+  }
+  @media (min-width: 48em) {
+    /* 768px, bootstrap "medium" and up */
   }
   .alert-heading {
     font-weight: 700;

--- a/src/js/components/CookieConsentBanner/index.svelte
+++ b/src/js/components/CookieConsentBanner/index.svelte
@@ -248,43 +248,6 @@
       align-items: center;
       padding: 0;
       justify-self: end;
-      border-radius: 0.375rem;
-      span.close-icon {
-        padding: 0.625rem;
-        border-radius: 50%;
-        width: 2rem;
-        height: 2rem;
-        //trying to animate these icons
-        display: block;
-        position: relative;
-        i {
-          color: var(--color-neutral-600);
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          transform: translate(-50%, -50%);
-          transition: opacity 0.25s ease-out;
-        }
-      }
-      .close-icon .icon-default {
-        opacity: 1;
-      }
-      .close-icon .icon-hover {
-        opacity: 0;
-      }
-      .close-icon:hover .icon-default,
-      .close-icon:focus .icon-default {
-        opacity: 0;
-        color: transparent;
-      }
-      .close-icon:hover .icon-hover,
-      .close-icon:focus .icon-hover {
-        opacity: 1;
-      }
-      &:focus-visible {
-        outline: 4px solid rgba(51, 51, 51, 0.4);
-        border-radius: 50%;
-      }
     }
     .close i {
       color: var(--color-neutral-600);

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -393,6 +393,54 @@ a:not(.btn,.list-group-item):has(i[aria-hidden]) {
    max-inline-size: min(90vw,70ch);
 }
 
+//close icon
+button.close {
+  &:focus-visible {
+    outline: 4px solid rgba(51, 51, 51, 0.4);
+    border-radius: 50%; 
+    .close-icon .icon-default {
+     opacity:0;
+      color:transparent; 
+    }
+    .close-icon .icon-hover {
+      opacity: 1;
+    }
+  }
+  .close-icon {
+  padding: 0.625rem;
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+  display: block;
+  position: relative;
+    i {
+      color: var(--color-neutral-600);
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      transition: opacity 0.25s ease-out;
+    }
+    .icon-default {
+      opacity: 1;
+    }
+    .icon-hover {
+      opacity: 0;
+    }
+    &:hover .icon-default,
+    &:focus .icon-default {
+      opacity:0;
+      color:transparent;
+    }
+    &:hover .icon-hover,
+    &:focus .icon-hover {
+      opacity: 1;
+    }
+  
+  }
+  
+}
+
 .px-modal {
   padding-left: var(--bs-modal-padding-width) !important;
   padding-right: var(--bs-modal-padding-width) !important;


### PR DESCRIPTION
Wrapping up DEV-1095:
- added a close button that dismisses the banner
- the dismiss function also sets a 14-day cookie "HT-alert-[id#]" to "dismiss" if users have allowed preference cookies
- cleaned up component markup
- edited component to use JSON data so we can easily swap in a JSON file later

See visual review of component in chromatic here: https://www.chromatic.com/review?appId=656a2bfa011def621f569319&number=70&type=linked&view=changes
And interactive component in chromatic here: https://www.chromatic.com/component?appId=656a2bfa011def621f569319&csfId=alert-banner&buildNumber=101&k=66351c0a22c6e1d67a85b355-1200px-interactive-true&h=13&b=-3