### PR TITLE
DEV-1165: feedback form issues

### DIFF
--- a/src/js/components/FeedbackFormBasic/FeedbackFormBasic.stories.js
+++ b/src/js/components/FeedbackFormBasic/FeedbackFormBasic.stories.js
@@ -35,18 +35,15 @@ export const DesktopFormFilled = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const name = await canvas.getByRole('textbox', { name: 'Name (required)' });
-    const email = await canvas.getByRole('textbox', {
-      name: 'Email address (required)',
+    // const name = await canvas.getByRole('textbox', { name: 'Name ' });
+    const name = await canvas.getByLabelText('Name (required)', {selector: 'input'});
+    const email = await canvas.getByLabelText('Email address (required)', {selector: 'input'});
+    const summary = await canvas.getByLabelText('Short summary (required)', {selector: 'input'});
+    const bookDescription = await canvas.getByLabelText('If your question is related to a specific book, what is the title or URL? (optional)', {
+      selector: 'input'
     });
-    const summary = await canvas.getByRole('textbox', {
-      name: 'Short summary (required)',
-    });
-    const bookDescription = await canvas.getByRole('textbox', {
-      name: 'If your question is related to a specific book, what is the title or URL? (optional)',
-    });
-    const description = await canvas.getByRole('textbox', {
-      name: 'Full description of problem or question (required)',
+    const description = await canvas.getByLabelText('Full description of problem or question (required)', {
+      selector: 'textarea'
     });
 
     await userEvent.type(name, 'Caryl Wyatt');
@@ -64,8 +61,8 @@ export const DesktopFormMissingRequiredFields = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const bookDescription = await canvas.getByRole('textbox', {
-      name: 'If your question is related to a specific book, what is the title or URL? (optional)',
+    const bookDescription = await canvas.getByLabelText('If your question is related to a specific book, what is the title or URL? (optional)', {
+      selector: 'input'
     });
 
     const submitButton = await canvas.getByRole('button', { name: 'Submit' });

--- a/src/js/components/FeedbackFormBasic/index.svelte
+++ b/src/js/components/FeedbackFormBasic/index.svelte
@@ -5,6 +5,11 @@
   let userURL = location.href;
   let userAgent = navigator.userAgent;
   let formName = 'basic-form';
+  let errorMessage,
+    nameError,
+    emailError,
+    summaryError,
+    descriptionError = false;
 
   //takes long string output of document.cookie and splits it into a usable javascript object
   let cookies = document.cookie
@@ -71,14 +76,32 @@
       event.stopPropagation();
       loading = false;
       formValid.classList.add('was-validated');
+      if (formValid.querySelector('#name.form-control:invalid')) {
+        nameError = true;
+      }
+      if (formValid.querySelector('#email.form-control:invalid')) {
+        emailError = true;
+      }
+      if (formValid.querySelector('#summary.form-control:invalid')) {
+        summaryError = true;
+      }
+      if (formValid.querySelector('#description.form-control:invalid')) {
+        descriptionError = true;
+      }
+      errorMessage = true;
     } else {
       // do the post fetch function, passing in the seralized data
       postForm(data)
-        // if no error, hide form and log new issue ID
+        // if no error, hide form, reset all the error messages, and log new issue ID
         .then((jiraResponseData) => {
           loading = false;
           submitted = true;
           hidden = true;
+          nameError = false;
+          emailError = false;
+          summaryError = false;
+          descriptionError = false;
+          errorMessage = false;
 
           console.log(
             `request created in service desk ${jiraResponseData.serviceDeskId}: ${jiraResponseData.issueKey}`
@@ -110,40 +133,68 @@
 <main>
   <form on:submit|preventDefault={onSubmit} class:hidden class="needs-validation mb-3" name="feedback" novalidate {id}>
     <div class="mb-3">
-      <label for="name" class="form-label">Name <span class="required">(required)</span></label>
-      <input type="name" class="form-control" id="name" name="name" required />
-      <div class="invalid-feedback">Please provide your name.</div>
-      <!-- <div id="emailHelp" class="form-text">We'll never share your email with anyone else.</div> -->
+      <label for="name" class="form-label">Name <span class="required" aria-hidden="true">(required)</span> </label>
+      <input aria-describedby="name-error" type="name" class="form-control" id="name" name="name" required />
+      <div class="invalid-feedback" id="name-error">
+        {#if nameError}
+          <span>Error: Please provide your name.</span>
+        {/if}
+      </div>
     </div>
     <div class="mb-3">
-      <label for="email" class="form-label">Email address <span class="required">(required)</span></label>
-      <input type="email" class="form-control" id="email" name="email" required />
-      <div class="invalid-feedback">Please provide an email address.</div>
+      <label for="email" class="form-label"
+        >Email address <span class="required" aria-hidden="true">(required)</span></label
+      >
+      <input type="email" class="form-control" id="email" name="email" aria-describedby="email-error" required />
+      <div class="invalid-feedback" id="email-error">
+        {#if emailError}<span>Error: Please provide an email address.</span>{/if}
+      </div>
     </div>
     <div class="mb-3">
-      <label for="summary" class="form-label">Short summary <span class="required">(required)</span></label>
-      <input type="text" class="form-control" id="summary" name="summary" required />
-      <div class="invalid-feedback">Please provide a title or subject line to summarize your feedback.</div>
+      <label for="summary" class="form-label"
+        >Short summary <span class="required" aria-hidden="true">(required)</span></label
+      >
+      <input type="text" class="form-control" id="summary" name="summary" aria-describedby="summary-error" required />
+      <div class="invalid-feedback" id="summary-error">
+        {#if summaryError}<span>Error: Please provide a title or subject line to summarize your feedback.</span>{/if}
+      </div>
     </div>
     <div class="mb-3">
       <label for="bookDescription" class="form-label"
-        >If your question is related to a specific book, what is the title or URL? <span class="required"
-          >(optional)</span
+        >If your question is related to a specific book, what is the title or URL? <span
+          class="required"
+          aria-hidden="true">(optional)</span
         ></label
       >
       <input type="text" class="form-control" id="bookDescription" name="bookDescription" />
     </div>
     <div class="mb-3">
       <label for="description" class="form-label"
-        >Full description of problem or question <span class="required">(required)</span></label
+        >Full description of problem or question <span class="required" aria-hidden="true">(required)</span></label
       >
-      <textarea class="form-control" id="description" name="description" rows="3" required />
-      <div class="invalid-feedback">Please provide some background or details for your feedback or question.</div>
+      <textarea
+        class="form-control"
+        aria-describedby="description-error"
+        id="description"
+        name="description"
+        rows="3"
+        required
+      />
+      <div class="invalid-feedback" id="description-error">
+        {#if descriptionError}<span
+            >Error: Please provide some background or details for your feedback or question.</span
+          >{/if}
+      </div>
     </div>
     <input name="userURL" id="userURL" type="hidden" bind:value={userURL} />
     <input name="userAgent" id="userAgent" type="hidden" bind:value={userAgent} />
     <input name="userAuthStatus" id="userAuthStatus" type="hidden" bind:value={userAuthStatus} />
     <input name="formName" id="formName" type="hidden" bind:value={formName} />
+    {#if errorMessage}
+      <div role="alert" class="mb-3">
+        The form did not submit due to errors in the fields. Please review error messages and resubmit the form.
+      </div>
+    {/if}
 
     <button type="submit" class="btn btn-primary" disabled={loading}>
       Submit{#if loading}

--- a/src/js/components/FeedbackFormCatalog/index.svelte
+++ b/src/js/components/FeedbackFormCatalog/index.svelte
@@ -7,6 +7,10 @@
   let userURL = location.href;
   let userAgent = navigator.userAgent;
   let formName = 'catalog-correction';
+  let errorMessage,
+    nameError,
+    emailError,
+    summaryError = false;
 
   //takes long string output of document.cookie and splits it into a usable javascript object
   let cookies = document.cookie
@@ -77,6 +81,16 @@
       event.stopPropagation();
       loading = false;
       formValid.classList.add('was-validated');
+      if (formValid.querySelector('#name.form-control:invalid')) {
+        nameError = true;
+      }
+      if (formValid.querySelector('#email.form-control:invalid')) {
+        emailError = true;
+      }
+      if (formValid.querySelector('#summary.form-control:invalid')) {
+        summaryError = true;
+      }
+      errorMessage = true;
     } else {
       // do the post fetch function, passing in the seralized data
       postForm(data)
@@ -85,6 +99,10 @@
           loading = false;
           submitted = true;
           hidden = true;
+          nameError = false;
+          emailError = false;
+          summaryError = false;
+          errorMessage = false;
 
           console.log(
             `request created in service desk ${jiraResponseData.serviceDeskId}: ${jiraResponseData.issueKey}`
@@ -117,23 +135,37 @@
 <main>
   <form on:submit|preventDefault={onSubmit} class:hidden class="needs-validation mb-3" name="feedback" novalidate {id}>
     <div class="mb-3">
-      <label for="name" class="form-label">Name <span class="required">(required)</span></label>
+      <label for="name" class="form-label">Name <span class="required" aria-hidden="true">(required)</span></label>
       <input type="name" class="form-control" id="name" name="name" required />
-      <div class="invalid-feedback">Please provide your name.</div>
+      <div class="invalid-feedback">
+        {#if nameError}
+          <span>Error: Please provide your name.</span>
+        {/if}
+      </div>
       <!-- <div id="emailHelp" class="form-text">We'll never share your email with anyone else.</div> -->
     </div>
     <div class="mb-3">
-      <label for="email" class="form-label">Email address <span class="required">(required)</span></label>
+      <label for="email" class="form-label"
+        >Email address <span class="required" aria-hidden="true">(required)</span></label
+      >
       <input type="email" class="form-control" id="email" name="email" required />
-      <div class="invalid-feedback">Please provide an email address.</div>
+      <div class="invalid-feedback">
+        {#if emailError}<span>Error: Please provide an email address.</span>{/if}
+      </div>
     </div>
     <div class="mb-3">
-      <label for="summary" class="form-label">Short summary <span class="required">(required)</span></label>
+      <label for="summary" class="form-label"
+        >Short summary <span class="required" aria-hidden="true">(required)</span></label
+      >
       <input type="text" class="form-control" id="summary" name="summary" required />
-      <div class="invalid-feedback">Please provide a title or subject line to summarize your feedback.</div>
+      <div class="invalid-feedback">
+        {#if summaryError}<span>Error: Please provide a title or subject line to summarize your feedback.</span>{/if}
+      </div>
     </div>
     <div class="mb-3">
-      <label for="recordURL" class="form-label">URL of catalog record <span class="required">(required)</span></label>
+      <label for="recordURL" class="form-label"
+        >URL of catalog record <span class="required" aria-hidden="true">(optional)</span></label
+      >
       <input type="text" class="form-control" id="recordURL" name="recordURL" />
       <div class="invalid-feedback">
         Please provide the URL of the record from the catalog where you found the issue.
@@ -141,48 +173,70 @@
     </div>
     <div class="mb-3">
       <label for="itemURL" class="form-label"
-        >URL of specific item within record related to issue <span class="required">(optional)</span></label
+        >URL of specific item within record related to issue <span class="required" aria-hidden="true">(optional)</span
+        ></label
       >
       <input type="text" class="form-control" id="itemURL" name="itemURL" />
     </div>
     <div class="mb-3">
-      <label for="itemTitle" class="form-label">Title of the book <span class="required">(optional)</span></label>
+      <label for="itemTitle" class="form-label"
+        >Title of the book <span class="required" aria-hidden="true">(optional)</span></label
+      >
       <input type="text" class="form-control" id="itemTitle" name="itemTitle" />
     </div>
     <fieldset class="mb-3">
       <legend class="mb-3 fs-6">
         What specific problems are you noticing with the catalog record?
-        <span class="required">(required)</span>
+        <span class="required" aria-hidden="true">(required)</span>
       </legend>
       <div class="form-check">
         <input
           class="form-check-input"
           type="checkbox"
+          role="checkbox"
           name="problems"
           value="Book doesn't match description"
+          id="c1"
           bind:group={problems}
         />
-        <label class="form-check-label" for="flexCheckDefault">
-          The book doesn't match the description in its catalog record
-        </label>
+        <label class="form-check-label" for="c1"> The book doesn't match the description in its catalog record </label>
       </div>
       <div class="form-check">
         <input
           class="form-check-input"
           type="checkbox"
+          role="checkbox"
           name="problems"
           value="Typo in metadata"
+          id="c2"
           bind:group={problems}
         />
-        <label class="form-check-label" for="flexCheckDefault"> There is a typo in the metadata </label>
+        <label class="form-check-label" for="c2"> There is a typo in the metadata </label>
       </div>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" name="problems" value="Other" bind:group={problems} />
-        <label class="form-check-label" for="flexCheckDefault"> Other (describe in description box) </label>
+        <input
+          class="form-check-input"
+          type="checkbox"
+          role="checkbox"
+          name="problems"
+          value="Other"
+          id="c3"
+          bind:group={problems}
+        />
+        <label class="form-check-label" for="c3"> Other (describe in description box) </label>
       </div>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" name="problems" value="None" bind:group={problems} checked />
-        <label class="form-check-label" for="flexCheckChecked"> No problems </label>
+        <input
+          class="form-check-input"
+          type="checkbox"
+          role="checkbox"
+          name="problems"
+          value="None"
+          id="c4"
+          bind:group={problems}
+          checked
+        />
+        <label class="form-check-label" for="c4"> No problems </label>
       </div>
     </fieldset>
     <fieldset class="mb-3">
@@ -235,7 +289,7 @@
     </fieldset>
     <div class="mb-3">
       <label for="description" class="form-label"
-        >Other problems or comments? <span class="optional">(required)</span></label
+        >Other problems or comments? <span class="required" aria-hidden="true">(optional)</span></label
       >
       <textarea class="form-control" id="description" name="description" rows="3" />
     </div>
@@ -243,6 +297,12 @@
     <input name="userAgent" id="userAgent" type="hidden" bind:value={userAgent} />
     <input name="userAuthStatus" id="userAuthStatus" type="hidden" bind:value={userAuthStatus} />
     <input name="formName" id="formName" type="hidden" bind:value={formName} />
+
+    {#if errorMessage}
+      <div role="alert" class="mb-3">
+        The form did not submit due to errors in the fields. Please review error messages and resubmit the form.
+      </div>
+    {/if}
 
     <button type="submit" class="btn btn-primary" disabled={loading}>
       Submit{#if loading}

--- a/src/js/components/FeedbackFormContent/index.svelte
+++ b/src/js/components/FeedbackFormContent/index.svelte
@@ -7,6 +7,11 @@
   let userURL = location.href;
   let userAgent = navigator.userAgent;
   let formName = 'content-correction';
+  let errorMessage,
+    nameError,
+    emailError,
+    summaryError,
+    urlError = false;
 
   //takes long string output of document.cookie and splits it into a usable javascript object
   let cookies = document.cookie
@@ -77,6 +82,19 @@
       event.stopPropagation();
       loading = false;
       formValid.classList.add('was-validated');
+      if (formValid.querySelector('#name.form-control:invalid')) {
+        nameError = true;
+      }
+      if (formValid.querySelector('#email.form-control:invalid')) {
+        emailError = true;
+      }
+      if (formValid.querySelector('#summary.form-control:invalid')) {
+        summaryError = true;
+      }
+      if (formValid.querySelector('#bookURL.form-control:invalid')) {
+        descriptionError = true;
+      }
+      errorMessage = true;
     } else {
       // do the post fetch function, passing in the seralized data
       postForm(data)
@@ -85,6 +103,11 @@
           loading = false;
           submitted = true;
           hidden = true;
+          nameError = false;
+          emailError = false;
+          summaryError = false;
+          urlError = false;
+          errorMessage = false;
 
           console.log(
             `request created in service desk ${jiraResponseData.serviceDeskId}: ${jiraResponseData.issueKey}`
@@ -117,32 +140,45 @@
 <main>
   <form on:submit|preventDefault={onSubmit} class:hidden class="needs-validation mb-3" name="feedback" novalidate {id}>
     <div class="mb-3">
-      <label for="name" class="form-label">Name <span class="required">(required)</span></label>
-      <input type="name" class="form-control" id="name" name="name" required />
-      <div class="invalid-feedback">Please provide your name.</div>
+      <label for="name" class="form-label">Name <span class="required" aria-hidden="true">(required)</span></label>
+      <input aria-describedby="name-error" type="name" class="form-control" id="name" name="name" required />
+      <div class="invalid-feedback" id="name-error">
+        {#if nameError}<span>Error: Please provide your name.</span>{/if}
+      </div>
       <!-- <div id="emailHelp" class="form-text">We'll never share your email with anyone else.</div> -->
     </div>
     <div class="mb-3">
-      <label for="email" class="form-label">Email address <span class="required">(required)</span></label>
-      <input type="email" class="form-control" id="email" name="email" required />
-      <div class="invalid-feedback">Please provide an email address.</div>
-    </div>
-    <div class="mb-3">
-      <label for="summary" class="form-label">Short summary <span class="required">(required)</span></label>
-      <input type="text" class="form-control" id="summary" name="summary" required />
-      <div class="invalid-feedback">Please provide a title or subject line to summarize your feedback.</div>
-    </div>
-    <div class="mb-3">
-      <label for="bookURL" class="form-label"
-        >URL of book that you are reporting a problem with <span class="required">(required)</span></label
+      <label for="email" class="form-label"
+        >Email address <span class="required" aria-hidden="true">(required)</span></label
       >
-      <input type="text" class="form-control" id="bookURL" name="bookURL" />
-      <div class="invalid-feedback">
-        Please provide the URL of the record from the catalog where you found the issue.
+      <input type="email" aria-describedby="email-error" class="form-control" id="email" name="email" required />
+      <div class="invalid-feedback" id="email-error">
+        {#if emailError}<span>Error: Please provide an email address.</span>{/if}
       </div>
     </div>
     <div class="mb-3">
-      <label for="itemTitle" class="form-label">Title of the book <span class="required">(optional)</span></label>
+      <label for="summary" class="form-label"
+        >Short summary <span class="required" aria-hidden="true">(required)</span></label
+      >
+      <input type="text" class="form-control" aria-describedby="summary-error" id="summary" name="summary" required />
+      <div class="invalid-feedback" id="summary-error">
+        {#if summaryError}<span>Error: Please provide a title or subject line to summarize your feedback.</span>{/if}
+      </div>
+    </div>
+    <div class="mb-3">
+      <label for="bookURL" class="form-label"
+        >URL of book that you are reporting a problem with <span class="required" aria-hidden="true">(required)</span
+        ></label
+      >
+      <input type="text" class="form-control" aria-describedby="url-error" id="bookURL" name="bookURL" />
+      <div class="invalid-feedback" id="url-error">
+        {#if urlError}<span>Please provide the URL of the record from the catalog where you found the issue.</span>{/if}
+      </div>
+    </div>
+    <div class="mb-3">
+      <label for="itemTitle" class="form-label"
+        >Title of the book <span class="required" aria-hidden="true">(optional)</span></label
+      >
       <input type="text" class="form-control" id="itemTitle" name="itemTitle" />
     </div>
 
@@ -151,7 +187,7 @@
         <p>What specific problems are you noticing with the digital scans?</p>
       </div>
       <legend class="mb-3 fs-6">
-        Overall page readability and quality <span class="required">(required)</span>
+        Overall page readability and quality <span class="required" aria-hidden="true">(required)</span>
       </legend>
       <div class="form-check">
         <input
@@ -218,7 +254,7 @@
     <fieldset class="mb-3">
       <legend class="mb-3 fs-6">
         Specific page image problems?
-        <span class="required">(required)</span>
+        <span class="required" aria-hidden="true">(required)</span>
       </legend>
       <div class="form-check">
         <input
@@ -226,9 +262,10 @@
           type="checkbox"
           name="imageProblems"
           value="Missing parts of the page"
+          id="c1"
           bind:group={imageProblems}
         />
-        <label class="form-check-label" for="flexCheckDefault"> Missing parts of the page </label>
+        <label class="form-check-label" for="c1"> Missing parts of the page </label>
       </div>
       <div class="form-check">
         <input
@@ -236,9 +273,10 @@
           type="checkbox"
           name="imageProblems"
           value="Blurry text"
+          id="c2"
           bind:group={imageProblems}
         />
-        <label class="form-check-label" for="flexCheckDefault"> Blurry text </label>
+        <label class="form-check-label" for="c2"> Blurry text </label>
       </div>
       <div class="form-check">
         <input
@@ -246,13 +284,21 @@
           type="checkbox"
           name="imageProblems"
           value="OCR unreadable"
+          id="c3"
           bind:group={imageProblems}
         />
-        <label class="form-check-label" for="flexCheckDefault"> The OCR is unreadable </label>
+        <label class="form-check-label" for="c3"> The OCR is unreadable </label>
       </div>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" name="imageProblems" value="Other" bind:group={imageProblems} />
-        <label class="form-check-label" for="flexCheckDefault"> Other (describe in description box) </label>
+        <input
+          class="form-check-input"
+          type="checkbox"
+          name="imageProblems"
+          value="Other"
+          id="c4"
+          bind:group={imageProblems}
+        />
+        <label class="form-check-label" for="c4"> Other (describe in description box) </label>
       </div>
       <div class="form-check">
         <input
@@ -260,15 +306,16 @@
           type="checkbox"
           name="imageProblems"
           value="No problems"
+          id="c5"
           bind:group={imageProblems}
           checked
         />
-        <label class="form-check-label" for="flexCheckChecked"> No problems </label>
+        <label class="form-check-label" for="c5"> No problems </label>
       </div>
     </fieldset>
     <div class="mb-3">
       <label for="description" class="form-label"
-        >Other problems or comments? <span class="required">(optional)</span></label
+        >Other problems or comments? <span class="required" aria-hidden="true">(optional)</span></label
       >
       <textarea class="form-control" id="description" name="description" rows="3" />
     </div>
@@ -276,6 +323,12 @@
     <input name="userAgent" id="userAgent" type="hidden" bind:value={userAgent} />
     <input name="userAuthStatus" id="userAuthStatus" type="hidden" bind:value={userAuthStatus} />
     <input name="formName" id="formName" type="hidden" bind:value={formName} />
+
+    {#if errorMessage}
+      <div role="alert" class="mb-3">
+        The form did not submit due to errors in the fields. Please review error messages and resubmit the form.
+      </div>
+    {/if}
 
     <button type="submit" class="btn btn-primary" disabled={loading}>
       Submit{#if loading}

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -76,6 +76,10 @@ $headings-font-weight: 700;
 $btn-font-weight: 800;
 $form-label-font-weight: 400;
 
+$ht-focus-border-color: #e1aa80;
+$ht-focus-box-shadow: inset 0 1px 2px #00000013,0 0 0 .25rem #c3540040;
+$ht-focus-outline: 0;
+
 // Required
 @import "~open-props/open-props.min.css";
 @import '~bootstrap/scss/functions';
@@ -283,6 +287,10 @@ $utilities: map-merge(
   --bs-body-font-weight: #{$body-font-weight};
   --bs-link-color: var(--color-primary-600);
   --ht-visited-link-color: #006FC3;
+
+  --ht-focus-border-color: #{$ht-focus-border-color};
+  --ht-focus-box-shadow: #{$ht-focus-box-shadow};
+  --ht-focus-outline: #${$ht-focus-outline};
 }
 
 body[data-initialized='true'] {
@@ -353,6 +361,14 @@ textarea.form-control {
 }
 .was-validated .form-check-input:valid:checked, .form-check-input.is-valid:checked, .was-validated .form-check-input:valid:checked, .form-check-input.is-valid:checked {
   background-color: var(--color-primary-600);
+}
+.was-validated .form-control:valid:focus, .form-control.is-valid:focus {
+    border-color: var(--ht-focus-border);
+    box-shadow: var(--ht-focus-box-shadow);
+    outline: var(--ht-focus-outline);
+}
+.was-validated .form-check-input:valid:focus, .form-check-input.is-valid:focus {
+  box-shadow: var(--ht-focus-box-shadow);
 }
 
 a:not(.btn,.list-group-item):has(i[aria-hidden]) {

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -341,6 +341,20 @@ textarea.form-control {
   border-bottom-left-radius: var(--bs-border-radius) !important;
 }
 
+.was-validated .form-control:valid, .form-control.is-valid {
+  border-color:  rgba(0, 0, 0, .25);
+  background-image: none;
+}
+.was-validated .form-check-input:valid~.form-check-label, .form-check-input.is-valid~.form-check-label {
+  color: inherit;
+}
+.was-validated .form-check-input:valid, .form-check-input.is-valid {
+  border-color: rgba(0, 0, 0, .25);
+}
+.was-validated .form-check-input:valid:checked, .form-check-input.is-valid:checked, .was-validated .form-check-input:valid:checked, .form-check-input.is-valid:checked {
+  background-color: var(--color-primary-600);
+}
+
 a:not(.btn,.list-group-item):has(i[aria-hidden]) {
   display: inline-flex;
   gap: 0.25rem;


### PR DESCRIPTION
This PR addresses two deque issues regarding the feedback form:

issue #71: [1727249](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/6a697dd4-fe27-11ee-bc1f-9f18b5e39269?sortField=severity&sortDir=desc&page=0&issuesCount=&filter%5Bcomponent_number%5D=1&row=0) green check mark validation on form fields lacking alternate text
issue #75: [1727235](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/d5e1e160-fe26-11ee-8084-d3b22a82817e?sortField=severity&sortDir=desc&page=0&issuesCount=&filter%5Bcomponent_number%5D=1&row=6) form validation error messages not being announced by screen reader

After discussion with Ange and Gayathri, we decided to remove the "valid" styles on feedback forms instead of adding text to the check mark icons that indicated a valid form field. Those styles were added to the global stylesheet.

The rest of the changes are updating the feedback form markup and javacript in order for a screen reader to announce error messages when a submitted form is invalid. While testing the feedback forms with VoiceOver, I realized that some of the form fields in the catalog and pt feedback forms were not being announced correctly (mainly that checkboxes weren't properly connected to their labels) and that the "required" and "optional" tags were being announced by the screen reader twice, so I hid that text for screen readers.

I also had to update the storybook tests for the general feedback form in response to the markup changes in the component.

This PR does not address all the [critical firebird fixes](https://github.com/hathitrust/firebird-common/issues/71), but I wanted to keep it small enough for someone to easily review.

## to test
This version of firebird is staged on dev-3. To test both the general feedback form and the catalog feedback form, go to [dev-3.catalog.hathitrust.org/Search/Home](https://dev-3.catalog.hathitrust.org/Search/Home) and use the "Get Help" button in the navbar to open either "Ask a Question" (general) or "Report a Bug" (catalog). This isn't staged for pt, but you could test this in a newer version babel-local-dev (with K'Ron's docker updates for front-end testing) if you really want. 