### PR TITLE
Dev 1165 advanced search form

### DIFF
--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -494,20 +494,20 @@
         {#each lookFors as value, idx}
           {#if idx > 0}
             <fieldset class="mb-3">
-              <legend class="visually-hidden">Boolean operator for field {idx - 1} and field {idx}</legend>
+              <legend class="visually-hidden">Boolean operator for field {idx} and field {idx + 1}</legend>
               <div class="d-flex gap-3 align-items-center justify-content-start">
                 {#each booleanOptions as option, bidx}
                   <div class="form-check">
                     <input
                       name="boolean-{idx}"
-                      id="boolean-{bidx}"
+                      id="boolean-{idx}_{bidx}"
                       type="radio"
                       class="form-check-input"
                       value={option.value}
                       checked={option.value == bools[idx]}
                       bind:group={bools[idx]}
                     />
-                    <label class="form-check-label text-uppercase" for="boolean-{bidx}">{option.value}</label>
+                    <label class="form-check-label text-uppercase" for="boolean-{idx}_{bidx}">{option.value}</label>
                   </div>
                 {/each}
               </div>

--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -649,7 +649,7 @@
         <fieldset class="mb-4">
           <legend class="fs-4 fw-bold">Language</legend>
 
-          <div>
+          <div class="advanced-search-list">
             <FilterableSelection
               --filterable-list-height="15rem"
               items={languageData.map((item) => ({
@@ -670,7 +670,7 @@
 
           <p>Select one or more options to narrow your results to items that match all of your format selections.</p>
 
-          <div>
+          <div class="advanced-search-list">
             <FilterableSelection
               --filterable-list-height="15rem"
               items={formatData.map((item) => ({

--- a/src/js/components/FeedbackFormCatalog/index.svelte
+++ b/src/js/components/FeedbackFormCatalog/index.svelte
@@ -193,7 +193,6 @@
         <input
           class="form-check-input"
           type="checkbox"
-          role="checkbox"
           name="problems"
           value="Book doesn't match description"
           id="c1"
@@ -205,7 +204,6 @@
         <input
           class="form-check-input"
           type="checkbox"
-          role="checkbox"
           name="problems"
           value="Typo in metadata"
           id="c2"
@@ -214,22 +212,13 @@
         <label class="form-check-label" for="c2"> There is a typo in the metadata </label>
       </div>
       <div class="form-check">
-        <input
-          class="form-check-input"
-          type="checkbox"
-          role="checkbox"
-          name="problems"
-          value="Other"
-          id="c3"
-          bind:group={problems}
-        />
+        <input class="form-check-input" type="checkbox" name="problems" value="Other" id="c3" bind:group={problems} />
         <label class="form-check-label" for="c3"> Other (describe in description box) </label>
       </div>
       <div class="form-check">
         <input
           class="form-check-input"
           type="checkbox"
-          role="checkbox"
           name="problems"
           value="None"
           id="c4"

--- a/src/js/components/FilterableSelection.svelte
+++ b/src/js/components/FilterableSelection.svelte
@@ -142,7 +142,7 @@
   }
 
   input:checked + label {
-    background: var(--color-primary-500, '#000') !important;
+    background: var(--color-primary-600, '#000') !important;
     color: white !important;
   }
 

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -369,6 +369,7 @@ textarea.form-control {
 }
 .was-validated .form-check-input:valid:focus, .form-check-input.is-valid:focus {
   box-shadow: var(--ht-focus-box-shadow);
+}
 .advanced-search-list li.form-check:focus-within {
     border: 2px solid var(--color-primary-600);
 }

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -369,6 +369,8 @@ textarea.form-control {
 }
 .was-validated .form-check-input:valid:focus, .form-check-input.is-valid:focus {
   box-shadow: var(--ht-focus-box-shadow);
+.advanced-search-list li.form-check:focus-within {
+    border: 2px solid var(--color-primary-600);
 }
 
 a:not(.btn,.list-group-item):has(i[aria-hidden]) {

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -373,6 +373,9 @@ textarea.form-control {
 .advanced-search-list li.form-check:focus-within {
     border: 2px solid var(--color-primary-600);
 }
+.advanced-search-list li.form-check:has(input:checked):focus-within {
+  border: 2px solid var(--color-neutral-800);
+}
 
 a:not(.btn,.list-group-item):has(i[aria-hidden]) {
   display: inline-flex;


### PR DESCRIPTION
Resolves some of #71 , #72 

Fixes for critical advanced search form issues:
- [1727510](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/136cd630-fe3f-11ee-b5ef-37a650e942e8?sortField=ordinal&sortDir=asc&filter%5Bpage_number%5D=6&row=0) radio button does not have role and/or state 
  - this was _close_ to being right, so it was an easy fix. the `id` attribute of the radio `<input>` and the `for` attribute of its corresponding `<label>` not only have to match, they must be _unique_. they matched before but were not unique, so I added an extra variable to the `id`/`for` combo and now we're good 👍 
- [1727483](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/848ccb44-fe3b-11ee-8829-bbb441666957?activeTab=dt-issue&page=0&pageSize=100&sortField=ordinal&sortDir=asc&row=0&searchKeyword=1727483&searchOn=id) focus indicator missing on select language and select format
  - I added an ugly focus ring on the `FilterableSelection` lists (language and format) on the advanced search forms, so now if you tab over them, you'll see a darker-orange box as you move through the list, and if you select an item with the space bar, the background of the them item turns orange and the focus ring turns black. Gayathri is working on a better design for all our focus states, butI wanted to fix this for now since it's a critical issue.

Other fixes:
- [1728295](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/cfa45d66-0063-11ef-93bf-030c24af5dbd?sortField=ordinal&sortDir=asc&filter%5Bpage_number%5D=6&row=0) select language/select format contrast issues
  - the `FilterableSelection` component was still using the inaccessible shade of orange (`primary-500`), so I updated it to the approved slightly-darker-orange (`primary-600`)
- in the previous PR for fixing the feedback forms, I didn't realize my linter was yelling at me that `role="checkbox"` is redundant when used with `type="checkbox"`, so I removed that here

## to test
This is staged on dev-3: Advanced Search page, either in [Catalog](https://dev-3.catalog.hathitrust.org/Search/Advanced) or [Full-text](https://dev-3.babel.hathitrust.org/cgi/ls?a=page&page=advanced). 

### boolean operators
To test the AND/OR boolean operator radio buttons, you'll need a screen reader. If you test in on prod, it's doing something like this:
<img width="907" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/065ec511-d5bf-40f8-b07f-893d1f32dd5b">
Because all the AND buttons had the same id/for attributes, they were all being read together like "AND AND AND" but if you use a screen reader on dev-3 and tab through this version of the form, it should read the ANDs and ORs separately now. 

Also, you may notice that the current version has this legend that says "Boolean operator for field 0 and field 1", and I fixed that, too. It will now say "Boolean operator for field 1 and field 2" and 2/3, 3/4 depending on which fieldset you're in.

### filterable selection list
You don't need the screen reader for this one, but it doesn't hurt. Tab through the language and format selection lists and select an item using the space bar. There should be a dark orange focus ring around unselected items, and selected items should have a black focus ring.
 
