### PR TITLE
fix matomo function

### DIFF
--- a/src/js/lib/analytics.js
+++ b/src/js/lib/analytics.js
@@ -44,7 +44,8 @@ export class AnalyticsManager {
     
   }
 
-  addMatomoScript() {
+  //need the arrow function syntax for 'this' to be defined
+  addMatomoScript = () => {
       var d = document,
         g = d.createElement('script'),
         s = d.getElementsByTagName('script')[0];


### PR DESCRIPTION
After staging the latest a11y fixes on dev-3, I noticed the console giving this error:

```sh
 Uncaught TypeError: Cannot read properties of undefined (reading 'service')
    at addMatomoScript (index-078c1e23.js:14:3660)
```
After some googling, I learned that in order to have the context of `this` in a method in javascript, you need to use the arrow function syntax. I tested this on dev-3 and it fixed the issue.