### PR TITLE
DEV-1180: contrast colors and universal focus indicator

### DIFF
--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -646,45 +646,47 @@
           </div>
         </fieldset>
 
-        <fieldset class="mb-4">
-          <legend class="fs-4 fw-bold">Language</legend>
+        <div>
+          <fieldset class="mb-4">
+            <legend class="fs-4 fw-bold">Language</legend>
 
-          <div class="advanced-search-list">
-            <FilterableSelection
-              --filterable-list-height="15rem"
-              items={languageData.map((item) => ({
-                option: item,
-                key: item,
-                value: item,
-              }))}
-              label="Language"
-              placeholder="Filter by language"
-              multiple={true}
-              bind:value={lang}
-            />
-          </div>
-        </fieldset>
+            <div class="advanced-search-list">
+              <FilterableSelection
+                --filterable-list-height="15rem"
+                items={languageData.map((item) => ({
+                  option: item,
+                  key: item,
+                  value: item,
+                }))}
+                label="Language"
+                placeholder="Filter by language"
+                multiple={true}
+                bind:value={lang}
+              />
+            </div>
+          </fieldset>
 
-        <fieldset class="mb-4">
-          <legend class="fs-4 fw-bold">Format</legend>
+          <fieldset class="mb-4">
+            <legend class="fs-4 fw-bold">Format</legend>
 
-          <p>Select one or more options to narrow your results to items that match all of your format selections.</p>
+            <p>Select one or more options to narrow your results to items that match all of your format selections.</p>
 
-          <div class="advanced-search-list">
-            <FilterableSelection
-              --filterable-list-height="15rem"
-              items={formatData.map((item) => ({
-                option: item,
-                key: item,
-                value: item,
-              }))}
-              label="Format"
-              placeholder="Filter by format"
-              multiple={true}
-              bind:value={format}
-            />
-          </div>
-        </fieldset>
+            <div class="advanced-search-list">
+              <FilterableSelection
+                --filterable-list-height="15rem"
+                items={formatData.map((item) => ({
+                  option: item,
+                  key: item,
+                  value: item,
+                }))}
+                label="Format"
+                placeholder="Filter by format"
+                multiple={true}
+                bind:value={format}
+              />
+            </div>
+          </fieldset>
+        </div>
 
         <div class="d-flex gap-3 mb-3 justify-content-end">
           <button class="btn btn-secondary" type="reset">

--- a/src/js/components/CookieConsentBanner/index.svelte
+++ b/src/js/components/CookieConsentBanner/index.svelte
@@ -151,7 +151,6 @@
     background: var(--color-primary-200);
     padding: 1.25rem 1rem;
     max-height: 34rem;
-
     .h2 {
       font-size: 1.25rem;
       line-height: 120%; /* 1.5rem */
@@ -175,7 +174,7 @@
       margin: 0;
       color: var(--color-neutral-900);
       a {
-        color: var(--color-primary-600);
+        color: var(--color-neutral-900);
       }
     }
 

--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -305,6 +305,7 @@
       font-weight: var(--btn-font-weight);
       letter-spacing: -0.01em;
       padding: 0.5em 0.75em;
+      transition-duration: 0s;
       &:focus-visible {
         outline: 2px solid var(--ht-focus-border-color) !important;
         outline-offset: 0;

--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -252,6 +252,11 @@
       display: flex;
       border: 0.5px solid var(--color-neutral-500);
       border-radius: 0.375em;
+      &:focus-within {
+        outline: 2px solid var(--ht-focus-border-color) !important;
+        z-index: 3;
+        border-radius: 6px 0 0 6px !important;
+      }
     }
     input {
       width: 100%;
@@ -264,10 +269,8 @@
         outline: 3px solid transparent;
       }
       &:focus-visible {
-        outline: 3px solid #086ab4 !important;
-        outline-offset: 4px;
-        z-index: 3;
-        border-radius: 6px !important;
+        outline: 3px solid transparent !important;
+        outline-offset: 0;
       }
     }
     .input-group-text {
@@ -290,6 +293,10 @@
       &:focus {
         outline: 3px solid transparent;
       }
+      &:focus-visible {
+        outline: 2px solid var(--ht-focus-border-color) !important;
+        outline-offset: 0;
+      }
     }
     button {
       border-radius: 0.375rem;
@@ -298,6 +305,11 @@
       font-weight: var(--btn-font-weight);
       letter-spacing: -0.01em;
       padding: 0.5em 0.75em;
+      &:focus-visible {
+        outline: 2px solid var(--ht-focus-border-color) !important;
+        outline-offset: 0;
+        box-shadow: inset 0 0 0 2px white !important;
+      }
     }
   }
   .search-details {
@@ -368,6 +380,7 @@
         @media (min-width: 992px) {
           flex-grow: 3;
         }
+
         .input-group-text {
           order: -1;
           border-top-left-radius: 0.375em !important;

--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -261,12 +261,13 @@
       border-bottom-right-radius: 0 !important;
       padding: 0.625em 0.75em;
       &:focus {
-        border-color: #e1aa80;
-        outline: 0;
-        box-shadow:
-          inset 0 1px 2px #00000013,
-          0 0 0 0.25rem #c3540040;
-        // outline: 3px solid transparent;
+        outline: 3px solid transparent;
+      }
+      &:focus-visible {
+        outline: 3px solid #086ab4 !important;
+        outline-offset: 4px;
+        z-index: 3;
+        border-radius: 6px !important;
       }
     }
     .input-group-text {
@@ -287,9 +288,6 @@
       border-radius: 0.375rem;
       margin-left: 0;
       &:focus {
-        // border-color: #e1aa80;
-        // outline: 0;
-        // box-shadow: inset 0 1px 2px #00000013, 0 0 0 0.25rem #c3540040;
         outline: 3px solid transparent;
       }
     }
@@ -399,6 +397,7 @@
         border-width: 0px 1px;
         border-style: solid;
         border-color: var(--color-neutral-100);
+        position: relative;
       }
       button {
         margin-left: -1px;

--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -263,7 +263,10 @@
       &:focus {
         border-color: #e1aa80;
         outline: 0;
-        box-shadow: inset 0 1px 2px #00000013, 0 0 0 0.25rem #c3540040;
+        box-shadow:
+          inset 0 1px 2px #00000013,
+          0 0 0 0.25rem #c3540040;
+        // outline: 3px solid transparent;
       }
     }
     .input-group-text {
@@ -277,8 +280,6 @@
         font-size: 14px;
       }
     }
-    .select-container:focus {
-    }
     .form-select {
       border: 0.5px solid var(--color-neutral-500);
       padding: 0.625em 0.75em;
@@ -286,9 +287,10 @@
       border-radius: 0.375rem;
       margin-left: 0;
       &:focus {
-        border-color: #e1aa80;
-        outline: 0;
-        box-shadow: inset 0 1px 2px #00000013, 0 0 0 0.25rem #c3540040;
+        // border-color: #e1aa80;
+        // outline: 0;
+        // box-shadow: inset 0 1px 2px #00000013, 0 0 0 0.25rem #c3540040;
+        outline: 3px solid transparent;
       }
     }
     button {

--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -253,6 +253,9 @@ body {
   }
 
   .table-branded {
+    a {
+      color: var(--color-primary-700);
+    }
     min-width: 100%;
     border-spacing: 0;
     --border: 1px solid var(--color-primary-500);

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -406,16 +406,16 @@ textarea.form-control {
 .was-validated .form-check-input:valid:focus, .form-check-input.is-valid:focus {
   box-shadow: none;
 }
+
 .advanced-search-list li.form-check:focus-within {
-    // border-left: 12px solid black;
     border: 4px dashed var(--ht-focus-border-color);
-    // & > label {
-    //   text-decoration: underline;
-    // }
+    & > label {
+      border:4px solid #fff;
+    }
 }
 .advanced-search-list li.form-check:not(:focus-within) > label {
-   padding: 12px 20px !important;
-   //padding-left: 28px !important;
+   padding: 16px 24px !important;
+   border:none !important;
 }
 
 a:not(.btn,.list-group-item):has(i[aria-hidden]) {

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -75,10 +75,53 @@ $body-font-weight: 500;
 $headings-font-weight: 700;
 $btn-font-weight: 800;
 $form-label-font-weight: 400;
+ 
 
-$ht-focus-border-color: #e1aa80;
+$ht-focus-border-color: #086AB4;
+
+// bootstrap focus style variables
+// but these change :focus not :focus-visible
+// $input-btn-focus-width:         3px; //firebird
+// $input-btn-focus-color-opacity: 1; //firebird
+// $input-btn-focus-color:         rgba($ht-focus-border-color, $input-btn-focus-color-opacity) !default;
+// $input-btn-focus-blur:          0 !default;
+// $input-btn-focus-box-shadow:    0 0 $input-btn-focus-blur $input-btn-focus-width $input-btn-focus-color !default;
+// $btn-focus-width:             $input-btn-focus-width !default;
+// $btn-focus-box-shadow:        $input-btn-focus-box-shadow !default;
+
+// $input-focus-bg:                        $input-bg !default;
+// $input-focus-border-color:              $ht-focus-border-color;
+// $input-focus-color:                     $input-color !default;
+// $input-focus-width:                     $input-btn-focus-width !default;
+// $input-focus-box-shadow:                $input-btn-focus-box-shadow !default;
+// $form-check-input-focus-border:           $input-focus-border-color !default;
+// $form-check-input-focus-box-shadow:       $input-btn-focus-box-shadow !default;
+// $form-switch-focus-color:         $input-focus-border-color !default;
+// $form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
+// $form-select-focus-border-color:  $input-focus-border-color !default;
+// $form-select-focus-width:         $input-focus-width !default;
+// $form-select-focus-box-shadow:    0 0 0 $form-select-focus-width $input-btn-focus-color !default;
+// $form-range-thumb-focus-box-shadow:        0 0 0 1px $body-bg, $input-focus-box-shadow !default;
+// $form-range-thumb-focus-box-shadow-width:  $input-focus-width !default; // For focus box shadow issue in Edge
+// $pagination-focus-color:            var(--#{$prefix}link-hover-color) !default;
+// $pagination-focus-bg:               $gray-200 !default;
+// $pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;
+// $pagination-focus-outline:          0 !default;
+// $accordion-button-focus-border-color:     $input-focus-border-color !default;
+// $accordion-button-focus-box-shadow:       $btn-focus-box-shadow !default;
+// $btn-close-focus-shadow:     $input-btn-focus-box-shadow !default;
+// $btn-close-focus-opacity:    1 !default;
+
 $ht-focus-box-shadow: inset 0 1px 2px #00000013,0 0 0 .25rem #c3540040;
 $ht-focus-outline: 0;
+
+:focus-visible {
+  border-radius: 6px !important;
+  outline: 3px solid #086AB4 !important;
+  box-shadow: 0 0 0 6px white;
+  outline-offset: 4px;
+  z-index: 3;
+}
 
 // Required
 @import "~open-props/open-props.min.css";
@@ -302,6 +345,7 @@ body[data-initialized='true'] {
 
 .btn {
   letter-spacing: -0.01rem;
+  
 }
 // bootstrap's contrast functions pair black text on our primary background
 .btn-primary {
@@ -316,6 +360,12 @@ body[data-initialized='true'] {
     background-color: var(--color-primary-700);
   }
 }
+// button:focus-visible {
+//   border-radius: 6px;
+//   border: 3px solid #086AB4;
+//   outline-offset: 4px;
+//   z-index:5;
+// }
 
 //bootstrap doesn't have a "tertiary" button, but we do
 .btn-tertiary {
@@ -328,9 +378,29 @@ body[data-initialized='true'] {
   --bs-btn-active-color: var(--bs-btn-hover-color);
   --bs-btn-active-bg: var(--bs-btn-hover-bg);
   --bs-btn-active-border-color: var(--bs-btn-hover-border-color);
+  // &:focus-visible {
+  //   outline: 4px solid rgba(51, 51, 51, .4);
+  // }
+}
+
+// FOCUS STYLES
+.btn, .accordion .accordion-button, select.form-select {
   &:focus-visible {
-    outline: 4px solid rgba(51, 51, 51, .4);
-  }
+      border-radius: 6px !important;
+      outline: 3px solid #086AB4 !important;
+      outline-offset: 4px;
+      box-shadow: 0 0 0 6px white;
+      z-index: 2;
+    }
+    &:focus:not(:focus-visible) {
+      z-index: 3;
+      border-color: var(--bs-accordion-btn-focus-border-color);
+      outline: 0;
+      box-shadow: var(--bs-accordion-btn-focus-box-shadow);
+    }
+    &:focus {
+      outline: 0.25rem solid transparent;
+    }
 }
 
 input.form-control[type],
@@ -348,6 +418,7 @@ textarea.form-control {
   border-top-left-radius: var(--bs-border-radius) !important;
   border-bottom-left-radius: var(--bs-border-radius) !important;
 }
+
 
 .was-validated .form-control:valid, .form-control.is-valid {
   border-color:  rgba(0, 0, 0, .25);
@@ -482,6 +553,7 @@ button.close {
   padding-right: var(--bs-modal-padding-width) !important;
 }
 
+
 .accordion {
   --bs-accordion-active-bg: transparent;
   --bs-accordion-active-color: var(--color-neutral-700);
@@ -507,14 +579,15 @@ a {
   // what effect does this have with padding?
   // padding: 2px 4px;
   transition: outline 0.3s ease, border-radius 0.3s ease, z-index 0.3s ease;
-  &:focus-visible {
-    outline: none;
+  // &:focus-visible {
+    // outline: 0.25rem solid transparent;
     // box-shadow: 0 0 0 4px rgba(236,114,23,0.5);
     // box-shadow: 0 0 0 4px rgb(51, 51, 51, 0.4);
-    outline: 4px solid rgb(51, 51, 51, 0.4);
-    border-radius: 4px;
-    z-index: 1;
-  }
+    // outline: 3px solid #086AB4;
+    // border-radius: 6px;
+    // outline-offset: 4px;
+    // z-index: 1;
+  // }
 }
 
 #skiplinks:focus-within {

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -384,20 +384,13 @@ body[data-initialized='true'] {
 }
 
 // FOCUS STYLES
-.btn, .accordion .accordion-button, select.form-select, input.form-ccontrol {
+.btn, .accordion .accordion-button, select.form-select, input.form-control, textarea.form-control, input.form-check-input {
   &:focus-visible {
-      border-radius: 6px !important;
       outline: 3px solid #086AB4 !important;
       outline-offset: 4px;
       box-shadow: 0 0 0 6px white;
-      z-index: 2;
+      z-index: 3;
     }
-    // &:focus:not(:focus-visible) {
-    //   z-index: 3;
-    //   border-color: var(--bs-accordion-btn-focus-border-color);
-    //   outline: 0;
-    //   box-shadow: var(--bs-accordion-btn-focus-box-shadow);
-    // }
     &:focus {
       outline: 3px solid transparent;
     }

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -78,47 +78,14 @@ $form-label-font-weight: 400;
  
 
 $ht-focus-border-color: #086AB4;
+$ht-focus-box-shadow: 0 0 0 6px #fff;
 
-// bootstrap focus style variables
-// but these change :focus not :focus-visible
-// $input-btn-focus-width:         3px; //firebird
-// $input-btn-focus-color-opacity: 1; //firebird
-// $input-btn-focus-color:         rgba($ht-focus-border-color, $input-btn-focus-color-opacity) !default;
-// $input-btn-focus-blur:          0 !default;
-// $input-btn-focus-box-shadow:    0 0 $input-btn-focus-blur $input-btn-focus-width $input-btn-focus-color !default;
-// $btn-focus-width:             $input-btn-focus-width !default;
-// $btn-focus-box-shadow:        $input-btn-focus-box-shadow !default;
-
-// $input-focus-bg:                        $input-bg !default;
-// $input-focus-border-color:              $ht-focus-border-color;
-// $input-focus-color:                     $input-color !default;
-// $input-focus-width:                     $input-btn-focus-width !default;
-// $input-focus-box-shadow:                $input-btn-focus-box-shadow !default;
-// $form-check-input-focus-border:           $input-focus-border-color !default;
-// $form-check-input-focus-box-shadow:       $input-btn-focus-box-shadow !default;
-// $form-switch-focus-color:         $input-focus-border-color !default;
-// $form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
-// $form-select-focus-border-color:  $input-focus-border-color !default;
-// $form-select-focus-width:         $input-focus-width !default;
-// $form-select-focus-box-shadow:    0 0 0 $form-select-focus-width $input-btn-focus-color !default;
-// $form-range-thumb-focus-box-shadow:        0 0 0 1px $body-bg, $input-focus-box-shadow !default;
-// $form-range-thumb-focus-box-shadow-width:  $input-focus-width !default; // For focus box shadow issue in Edge
-// $pagination-focus-color:            var(--#{$prefix}link-hover-color) !default;
-// $pagination-focus-bg:               $gray-200 !default;
-// $pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;
-// $pagination-focus-outline:          0 !default;
-// $accordion-button-focus-border-color:     $input-focus-border-color !default;
-// $accordion-button-focus-box-shadow:       $btn-focus-box-shadow !default;
-// $btn-close-focus-shadow:     $input-btn-focus-box-shadow !default;
-// $btn-close-focus-opacity:    1 !default;
-
-$ht-focus-box-shadow: inset 0 1px 2px #00000013,0 0 0 .25rem #c3540040;
-$ht-focus-outline: 0;
+// $ht-focus-box-shadow: inset 0 1px 2px #00000013,0 0 0 .25rem #c3540040;
+// $ht-focus-outline: 0;
 
 :focus-visible {
-  border-radius: 6px !important;
   outline: 3px solid #086AB4 !important;
-  box-shadow: 0 0 0 6px white;
+  box-shadow: 0 0 0 6px #fff;
   outline-offset: 4px;
   z-index: 3;
 }
@@ -333,7 +300,7 @@ $utilities: map-merge(
 
   --ht-focus-border-color: #{$ht-focus-border-color};
   --ht-focus-box-shadow: #{$ht-focus-box-shadow};
-  --ht-focus-outline: #${$ht-focus-outline};
+  // --ht-focus-outline: #${$ht-focus-outline};
 }
 
 body[data-initialized='true'] {
@@ -384,7 +351,7 @@ body[data-initialized='true'] {
 }
 
 // FOCUS STYLES
-.btn, .accordion .accordion-button, select.form-select, input.form-control, textarea.form-control, input.form-check-input {
+.btn, .accordion .accordion-button, select.form-select, input.form-control, textarea.form-control, input.form-check-input, :is(.was-validated) :is(.form-control, .form-select, .form-check-input) {
   &:focus-visible {
       outline: 3px solid #086AB4 !important;
       outline-offset: 4px;
@@ -396,6 +363,9 @@ body[data-initialized='true'] {
     }
 }
 
+.form-check-input, .form-control, .form-select {
+  border: 1px solid var(--color-neutral-500);
+}
 input.form-control[type],
 textarea.form-control {
   background-color: var(--color-neutral-50);
@@ -414,32 +384,39 @@ textarea.form-control {
 
 
 .was-validated .form-control:valid, .form-control.is-valid {
-  border-color:  rgba(0, 0, 0, .25);
+  border-color:  var(--color-neutral-500);
   background-image: none;
 }
 .was-validated .form-check-input:valid~.form-check-label, .form-check-input.is-valid~.form-check-label {
   color: inherit;
 }
 .was-validated .form-check-input:valid, .form-check-input.is-valid {
-  border-color: rgba(0, 0, 0, .25);
+  border-color:  var(--color-neutral-500);
 }
 .was-validated .form-check-input:valid:checked, .form-check-input.is-valid:checked, .was-validated .form-check-input:valid:checked, .form-check-input.is-valid:checked {
   background-color: var(--color-primary-600);
 }
 .was-validated .form-control:valid:focus, .form-control.is-valid:focus {
-    border-color: var(--ht-focus-border);
-    box-shadow: var(--ht-focus-box-shadow);
-    outline: var(--ht-focus-outline);
-}
-.was-validated .form-check-input:valid:focus, .form-check-input.is-valid:focus {
+  border-color:  var(--color-neutral-500);
   box-shadow: var(--ht-focus-box-shadow);
 }
+.was-validated .form-check-input:valid:focus, .form-check-input.is-valid:focus {
+  box-shadow: none;
+}
 .advanced-search-list li.form-check:focus-within {
-    border: 2px solid var(--color-primary-600);
+    // outline: 3px solid #086AB4 !important;
+    // border: 3px solid white;
+    border-left: 12px solid black;
+    // & > label {
+    //   text-decoration: underline;
+    // }
 }
-.advanced-search-list li.form-check:has(input:checked):focus-within {
-  border: 2px solid var(--color-neutral-800);
+.advanced-search-list li.form-check:not(:focus-within) > label {
+   padding-left: 28px !important;
 }
+// .advanced-search-list li.form-check:has(input:checked):focus-within {
+//   border: 2px solid var(--color-neutral-800);
+// }
 
 a:not(.btn,.list-group-item):has(i[aria-hidden]) {
   display: inline-flex;

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -384,7 +384,7 @@ body[data-initialized='true'] {
 }
 
 // FOCUS STYLES
-.btn, .accordion .accordion-button, select.form-select {
+.btn, .accordion .accordion-button, select.form-select, input.form-ccontrol {
   &:focus-visible {
       border-radius: 6px !important;
       outline: 3px solid #086AB4 !important;
@@ -392,14 +392,14 @@ body[data-initialized='true'] {
       box-shadow: 0 0 0 6px white;
       z-index: 2;
     }
-    &:focus:not(:focus-visible) {
-      z-index: 3;
-      border-color: var(--bs-accordion-btn-focus-border-color);
-      outline: 0;
-      box-shadow: var(--bs-accordion-btn-focus-box-shadow);
-    }
+    // &:focus:not(:focus-visible) {
+    //   z-index: 3;
+    //   border-color: var(--bs-accordion-btn-focus-border-color);
+    //   outline: 0;
+    //   box-shadow: var(--bs-accordion-btn-focus-box-shadow);
+    // }
     &:focus {
-      outline: 0.25rem solid transparent;
+      outline: 3px solid transparent;
     }
 }
 

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -362,6 +362,9 @@ body[data-initialized='true'] {
       outline: 3px solid transparent;
     }
 }
+a:focus-visible {
+  border-radius: 6px;
+}
 
 .form-check-input, .form-control, .form-select {
   border: 1px solid var(--color-neutral-500);
@@ -404,19 +407,16 @@ textarea.form-control {
   box-shadow: none;
 }
 .advanced-search-list li.form-check:focus-within {
-    // outline: 3px solid #086AB4 !important;
-    // border: 3px solid white;
-    border-left: 12px solid black;
+    // border-left: 12px solid black;
+    border: 4px dashed var(--ht-focus-border-color);
     // & > label {
     //   text-decoration: underline;
     // }
 }
 .advanced-search-list li.form-check:not(:focus-within) > label {
-   padding-left: 28px !important;
+   padding: 12px 20px !important;
+   //padding-left: 28px !important;
 }
-// .advanced-search-list li.form-check:has(input:checked):focus-within {
-//   border: 2px solid var(--color-neutral-800);
-// }
 
 a:not(.btn,.list-group-item):has(i[aria-hidden]) {
   display: inline-flex;


### PR DESCRIPTION
The theme of this pull request is 🌈 colors 🎨 . The problems addressed with these color updates are contrast between the background color and color of specific text areas, form element borders, striped tables, and focus indicators throughout the website and applications. Fixes issue #78 

These fixes have been staged on dev-3:
- [website](https://dev-3.www.hathitrust.org/)
- [search results](https://dev-3.babel.hathitrust.org/cgi/ls?q1=elephant&field1=ocr&a=srchls&ft=ft&lmt=ft)
- [page turner](https://dev-3.babel.hathitrust.org/cgi/pt?id=umn.31951p00906792z&seq=3)

Deque "checkpoints" we can consider complete: 
- [Color contrast (regular text)](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issues?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.3.a) 
- [Non-text contrast - active user interface components](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issues?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.a)
- [Non-text contrast - states of user interface components](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issues?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b)

## Color contrast (regular text)

### Cookie consent banner links 
Issues [1727008](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/7791cc2a-fe0c-11ee-9802-ff5301e1cb0d?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.3.a&row=0) and [1727009](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/7791d88c-fe0c-11ee-9803-a7ce18872a77?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.3.a&row=0)

You might have to clear your cookies to see it on dev-3, but we changed the links from orange to black: 
<img width="570" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/db6a8c51-d9f0-4bae-8a0a-08e20754eadc">

### Striped tables
Fixes issue #76 
The link color in striped tables on catalog records didn't have sufficient color contrast, so we darkened the links in those tables by one shade (`primary-600` -> `primary-700`).
Deque issues: 72 of the same issue, like this one: [1727028](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/9e2b8e72-fe0f-11ee-b66d-7fd397a7fde1?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.3.a&row=0)
<img width="786" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/ef194711-1211-4d9e-b733-e147128fd91c">


## Non-text contrast - active user interface components
Form element borders like checkboxes, radio selects, dropdown selects, text inputs all had improper contrast. We darkened the outline from the standard bootstrap `rgba(51, 51, 51, .4)` (basically a dark gray with the opacity turned down) to `neutral-500`.

(9 issues total, 2 marked as wont-do) [1727200](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/26f7a096-fe20-11ee-82fb-c7e7c10ddaa4?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.a&row=0), [1727428](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/52dfb086-fe34-11ee-8af8-d30071727c2a?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.a&row=0), [1727437](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/a9e35094-fe35-11ee-8edf-dbc2b15e13ce?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.a&row=0), [1727485](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/a9663856-fe3b-11ee-a3cb-93ec9916926a?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.a&row=0), [1727509](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/08f3a3f0-fe3f-11ee-b17f-9b79db14f688?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.a&row=0), [1727692](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/8d78e0f8-fe68-11ee-8e18-bbbd21e1dc8f?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.a&row=0), [1728710](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/87f280ae-008d-11ef-bf9b-43e3d09ee7aa?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.a&row=0)

## Non-text contrast - states of user interface components
Fixes issue #83 

Our focus indicators were a mixed bag of blurred opacity borders (standard in bootstrap components). Because our primary color orange is already skirting the boundary of acceptable contrast, adding opacity to it made it worse. @giramesh designed a new universal focus indicator to work against all background colors. The new design is a solid 3px blue outline with a 6px white box shadow inside of it to ensure that any background will pass the contrast ratio for either the blue or the white. It's lovely!

Examples:
<img width="407" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/7520abd2-ac58-4cfb-9d75-409ffc4a15be">
<img width="571" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/6e05904a-c5a8-40e6-bf7a-209eee9a4fdc">
<img width="244" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/f9112f01-3d3a-40bf-9faa-e039000a77cd">
<img width="525" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/02fceac3-537a-4f7d-832a-2eb6cb838991">

### Special case

Multi-select option in advanced search has a unique focus indicator because it's a unique use-case:
<img width="844" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/44b531a9-6767-4cc8-8a97-01171ae769ef">
<img width="819" alt="image" src="https://github.com/hathitrust/firebird-common/assets/7959762/2eae562a-e0c5-4348-abfd-134fa5ff326b">

Issues: (27 issues total, 1 marked wont-do): [1727129](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/4ba2d594-fe13-11ee-9bfc-7ba43148f91e?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727135](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/a84ce8c4-fe14-11ee-bdfb-73ecdfb1abee?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727185](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/3b8e480e-fe1e-11ee-a62b-2bed5b31fe91?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727213](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/041d0866-fe22-11ee-9363-6792c3e5c529?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727217](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/9c93514a-fe22-11ee-a232-47f9a185eb6f?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727223](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/1d885f9c-fe24-11ee-a67c-7370a7d4e4ff?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727228](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/67aed118-fe25-11ee-b924-234740bbb337?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727261](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/0e6f8cf2-fe28-11ee-b014-43b38b3a4811?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727309](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/e478341c-fe2c-11ee-8012-8bd2ed5cbefe?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727427](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/1129c01e-fe34-11ee-b6f6-430d0eda078f?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727443](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/7673fe7e-fe36-11ee-a526-139a232a71b6?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727458](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/df84d17e-fe39-11ee-a453-2325b08d9c33?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727473](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/a1d03386-fe3a-11ee-a69a-4f2c07d40424?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727478](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/158203a4-fe3b-11ee-a7fe-e33c2c1b9aa6?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727508](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/04ec310a-fe3f-11ee-90d2-1f9efe825575?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727514](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/2759e52a-fe3f-11ee-a425-4bf9faa7a23c?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727515](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/40d86a08-fe3f-11ee-920a-9fd8e4ec7af2?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727523](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/7b6d45d4-fe40-11ee-8ac6-075befaa9566?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727547](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/7b601db2-fe47-11ee-a811-1796a0b6d087?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727552](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/235bee1c-fe4b-11ee-9198-a794e0a50b4a?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&row=0), [1727821](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/f6a7655a-feda-11ee-be60-c7ae65f70204?activeTab=issues-list&page=1&sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&pageSize=10&xhr=true&_=1718635569064), [1727962](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/a667b15a-ff14-11ee-9f4a-9f9912802e4e?activeTab=issues-list&page=1&sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&pageSize=10&xhr=true&_=1718635569081), [1727972](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/d1ec9cfc-ff17-11ee-ab64-8b2e1f1b024e?activeTab=issues-list&page=1&sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&pageSize=10&xhr=true&_=1718635569081), [1727975](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/0cb64ae0-ff1d-11ee-934f-6ff1ae8d2d9c?activeTab=issues-list&page=1&sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&pageSize=10&xhr=true&_=1718635569081), [1728319](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/343606c2-0068-11ef-9907-474792858376?activeTab=issues-list&page=1&sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&pageSize=10&xhr=true&_=1718635569081), [1728578](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/4fe08638-0084-11ef-8090-3fcf358b061a?activeTab=issues-list&page=1&sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=1.4.11.b&pageSize=10&xhr=true&_=1718635569081)
