### PR TITLE
DEV-1174: add aria-expanded for navbar search toggle

### DIFF
--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -309,6 +309,7 @@
               class:search-active={searchOpen}
               href="#"
               role="button"
+              aria-expanded={searchOpen}
               on:click|preventDefault|stopPropagation={toggleSearch}
               >Search <i class="fa-solid fa-magnifying-glass fa-fw" /></a
             >


### PR DESCRIPTION
Fixes #73 and [1727026](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/302de104-fe0f-11ee-ac5b-ff3565d28288?sortField=severity&sortDir=desc&page=0&issuesCount=&filter%5Bcomponent_number%5D=1&row=5) _expand/collapse on search bar isn't setting aria expanded correctly_

Added `aria-expanded` attribute to the Search icon in the navbar to alert screen readers when the search bar is open or closed.

This fix is staged on dev-3 (vpn required): https://dev-3.www.hathitrust.org/

If you inspect the "search 🔍 " button in the navbar, it should now have an `aria-expanded` attribute set to `true` if the search bar is toggled to open (default on most pages). Toggle it closed, and the attribute should be set to `false`.