### PR TITLE
DEV-1179: small component fixes

### DIFF
--- a/src/js/components/CollectionEditModal/index.svelte
+++ b/src/js/components/CollectionEditModal/index.svelte
@@ -95,22 +95,31 @@
         </div>
       </div>
       <div class="mb-0">
-        <p class="mb-1">Is this collection visible to others?</p>
-        <div class="d-flex">
-          <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="shared" id="shared-0" value={0} bind:group={shared} />
-            <label class="form-check-label" for="shared-0">
-              <i class="fa-solid fa-lock" aria-hidden="true" />
-              Private
-            </label>
-          </div>
-          {#if !userIsAnonymous}
+        <fieldset>
+          <legend class="fs-4 mb-1">Is this collection visible to others?</legend>
+          <div class="d-flex">
             <div class="form-check form-check-inline">
-              <input class="form-check-input" type="radio" name="shared" id="shared-1" value={1} bind:group={shared} />
-              <label class="form-check-label" for="shared-1"> Public </label>
+              <input class="form-check-input" type="radio" name="shared" id="shared-0" value={0} bind:group={shared} />
+              <label class="form-check-label" for="shared-0">
+                <i class="fa-solid fa-lock" aria-hidden="true" />
+                Private
+              </label>
             </div>
-          {/if}
-        </div>
+            {#if !userIsAnonymous}
+              <div class="form-check form-check-inline">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  name="shared"
+                  id="shared-1"
+                  value={1}
+                  bind:group={shared}
+                />
+                <label class="form-check-label" for="shared-1"> Public </label>
+              </div>
+            {/if}
+          </div>
+        </fieldset>
       </div>
     </form>
   </svelte:fragment>

--- a/src/js/components/CollectionsToolbar/index.svelte
+++ b/src/js/components/CollectionsToolbar/index.svelte
@@ -291,7 +291,11 @@
   role="toolbar"
   aria-label="Collections toolbar"
 >
-  <button class="btn btn-outline-light d-flex align-items-center gap-2 flex-nowrap" on:click={selectAllItems}>
+  <button
+    class="btn btn-outline-light d-flex align-items-center gap-2 flex-nowrap"
+    aria-pressed={allItemsSelected}
+    on:click={selectAllItems}
+  >
     {#if allItemsSelected}
       <i class="fa-solid fa-square-check" aria-hidden="true" />
     {:else}


### PR DESCRIPTION
Fixes issue #77 and deque issues [1728595](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/894525ee-0086-11ef-a8dd-db78ee811ab9?viewMode=issues&sortField=ordinal&sortDir=asc&filter%5Bcomponent_number%5D=6&row=1), [1727518](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/5ed7f8f2-fe3f-11ee-8326-b71c7e04ea6a?sortField=severity&sortDir=desc&page=0&issuesCount=&row=5&filter%5Bpage_number%5D=0), [1728277](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/0a3e3cbc-005a-11ef-8764-cf40999bf5e1?viewMode=issues&sortField=ordinal&sortDir=asc&row=0&filter%5Bpage_number%5D=5)

## Collection edit modal

This modal is a form, and the radio buttons under "Is this collection visible to others?" weren't accessible due to a missing legend/fieldset combo. I changed the paragraph to a legend and surrounded the radio button field with the fieldset tags. 

To test: On dev-3 (vpn required), test either [ls search results](https://dev-3.babel.hathitrust.org/cgi/ls?q1=elephant&field1=ocr&a=srchls&ft=ft&lmt=ft) or any collection. Check the checkbox next to an item, and select "Add" from the toolbar. You should get a modal! Test this with a screen reader: when you tab to the radio buttons, it should now announce the radio button that is selected _and_ the question in the legend ("Is this collection visible to others?").

## Collections toolbar

The collection toolbar has a "Select all" button that uses a checkbox/checkmark _icon_ instead of an actual checkbox 🙃  in order to indicate to screen readers whether this button is "pressed" or "unpressed" (since it's not a checkbox with the built-in "checked" attribute), we needed to add `aria-pressed` and indicate whether that's true/false.

To test: open any collection on dev-3 (like [this one](https://dev-3.babel.hathitrust.org/cgi/mb?a=listis;c=464226859)), inspect the "Select all button" in the dev tools to see the new `aria-pressed` attribute. If the button has an empty checkbox icon, the attribute should be "false." Press the button, see the icon turn to a checked box, and `aria-pressed` should be `true`.
