### PR TITLE
DEV-1177: finish up feedback form fixes

### DIFF
--- a/src/js/components/FeedbackFormBasic/index.svelte
+++ b/src/js/components/FeedbackFormBasic/index.svelte
@@ -134,7 +134,15 @@
   <form on:submit|preventDefault={onSubmit} class:hidden class="needs-validation mb-3" name="feedback" novalidate {id}>
     <div class="mb-3">
       <label for="name" class="form-label">Name <span class="required" aria-hidden="true">(required)</span> </label>
-      <input aria-describedby="name-error" type="name" class="form-control" id="name" name="name" required />
+      <input
+        aria-describedby="name-error"
+        type="name"
+        class="form-control"
+        id="name"
+        name="name"
+        autocomplete="name"
+        required
+      />
       <div class="invalid-feedback" id="name-error">
         {#if nameError}
           <span>Error: Please provide your name.</span>
@@ -145,7 +153,15 @@
       <label for="email" class="form-label"
         >Email address <span class="required" aria-hidden="true">(required)</span></label
       >
-      <input type="email" class="form-control" id="email" name="email" aria-describedby="email-error" required />
+      <input
+        type="email"
+        class="form-control"
+        id="email"
+        name="email"
+        aria-describedby="email-error"
+        autocomplete="email"
+        required
+      />
       <div class="invalid-feedback" id="email-error">
         {#if emailError}<span>Error: Please provide an email address.</span>{/if}
       </div>

--- a/src/js/components/FeedbackFormCatalog/index.svelte
+++ b/src/js/components/FeedbackFormCatalog/index.svelte
@@ -136,7 +136,7 @@
   <form on:submit|preventDefault={onSubmit} class:hidden class="needs-validation mb-3" name="feedback" novalidate {id}>
     <div class="mb-3">
       <label for="name" class="form-label">Name <span class="required" aria-hidden="true">(required)</span></label>
-      <input type="name" class="form-control" id="name" name="name" required />
+      <input type="name" class="form-control" id="name" autocomplete="name" name="name" required />
       <div class="invalid-feedback">
         {#if nameError}
           <span>Error: Please provide your name.</span>
@@ -148,7 +148,7 @@
       <label for="email" class="form-label"
         >Email address <span class="required" aria-hidden="true">(required)</span></label
       >
-      <input type="email" class="form-control" id="email" name="email" required />
+      <input type="email" class="form-control" id="email" autocomplete="email" name="email" required />
       <div class="invalid-feedback">
         {#if emailError}<span>Error: Please provide an email address.</span>{/if}
       </div>

--- a/src/js/components/FeedbackFormContent/index.svelte
+++ b/src/js/components/FeedbackFormContent/index.svelte
@@ -141,7 +141,15 @@
   <form on:submit|preventDefault={onSubmit} class:hidden class="needs-validation mb-3" name="feedback" novalidate {id}>
     <div class="mb-3">
       <label for="name" class="form-label">Name <span class="required" aria-hidden="true">(required)</span></label>
-      <input aria-describedby="name-error" type="name" class="form-control" id="name" name="name" required />
+      <input
+        aria-describedby="name-error"
+        type="name"
+        autocomplete="name"
+        class="form-control"
+        id="name"
+        name="name"
+        required
+      />
       <div class="invalid-feedback" id="name-error">
         {#if nameError}<span>Error: Please provide your name.</span>{/if}
       </div>
@@ -151,7 +159,15 @@
       <label for="email" class="form-label"
         >Email address <span class="required" aria-hidden="true">(required)</span></label
       >
-      <input type="email" aria-describedby="email-error" class="form-control" id="email" name="email" required />
+      <input
+        type="email"
+        aria-describedby="email-error"
+        autocomplete="email"
+        class="form-control"
+        id="email"
+        name="email"
+        required
+      />
       <div class="invalid-feedback" id="email-error">
         {#if emailError}<span>Error: Please provide an email address.</span>{/if}
       </div>

--- a/src/js/components/FeedbackFormModal/index.svelte
+++ b/src/js/components/FeedbackFormModal/index.svelte
@@ -7,7 +7,6 @@
   let modal;
   export let form = 'basic';
   export let isOpen = false;
-  export let dropdownLinkTrigger;
 
   export const show = function () {
     isOpen = true;
@@ -45,7 +44,7 @@
 
 <div>
   {#if form == 'catalog'}
-    <Modal bind:this={modal} {dropdownLinkTrigger} openHelpDropdownOnModalClose scrollable>
+    <Modal bind:this={modal} focusHelpOnClose scrollable>
       <svelte:fragment slot="title">Catalog Quality Correction</svelte:fragment>
       <svelte:fragment slot="body">
         {#if winterBreak}<p>{@html message}</p>{/if}
@@ -53,7 +52,7 @@
       </svelte:fragment>
     </Modal>
   {:else if form == 'content'}
-    <Modal bind:this={modal} {dropdownLinkTrigger} openHelpDropdownOnModalClose scrollable>
+    <Modal bind:this={modal} focusHelpOnClose scrollable>
       <svelte:fragment slot="title">Content Quality Correction</svelte:fragment>
       <svelte:fragment slot="body">
         {#if winterBreak}<p>{@html message}</p>{/if}
@@ -61,7 +60,7 @@
       </svelte:fragment>
     </Modal>
   {:else if form == 'basic'}
-    <Modal bind:this={modal} {dropdownLinkTrigger} openHelpDropdownOnModalClose scrollable>
+    <Modal bind:this={modal} focusHelpOnClose scrollable>
       <svelte:fragment slot="title">Questions?</svelte:fragment>
       <svelte:fragment slot="body">
         {#if winterBreak}<p>{@html message}</p>{/if}
@@ -69,7 +68,7 @@
       </svelte:fragment>
     </Modal>
   {:else}
-    <Modal bind:this={modal} {dropdownLinkTrigger} openHelpDropdownOnModalClose scrollable>
+    <Modal bind:this={modal} focusHelpOnClose scrollable>
       <svelte:fragment slot="title">Questions?</svelte:fragment>
       <svelte:fragment slot="body">
         {#if winterBreak}<p>{@html message}</p>{/if}

--- a/src/js/components/FeedbackFormModal/index.svelte
+++ b/src/js/components/FeedbackFormModal/index.svelte
@@ -7,15 +7,13 @@
   let modal;
   export let form = 'basic';
   export let isOpen = false;
+  export let dropdownLinkTrigger;
 
   export const show = function () {
     isOpen = true;
     modal.show();
   };
 
-  export const hide = function () {
-    modal.hide();
-  };
   onMount(() => {
     if (isOpen && modal) {
       modal.show();
@@ -24,9 +22,6 @@
 
   $: if (modal && isOpen) {
     show();
-  }
-  $: if (modal && !isOpen) {
-    hide();
   }
 
   let today = new Date();
@@ -50,7 +45,7 @@
 
 <div>
   {#if form == 'catalog'}
-    <Modal bind:this={modal} scrollable>
+    <Modal bind:this={modal} {dropdownLinkTrigger} openHelpDropdownOnModalClose scrollable>
       <svelte:fragment slot="title">Catalog Quality Correction</svelte:fragment>
       <svelte:fragment slot="body">
         {#if winterBreak}<p>{@html message}</p>{/if}
@@ -58,7 +53,7 @@
       </svelte:fragment>
     </Modal>
   {:else if form == 'content'}
-    <Modal bind:this={modal} scrollable>
+    <Modal bind:this={modal} {dropdownLinkTrigger} openHelpDropdownOnModalClose scrollable>
       <svelte:fragment slot="title">Content Quality Correction</svelte:fragment>
       <svelte:fragment slot="body">
         {#if winterBreak}<p>{@html message}</p>{/if}
@@ -66,7 +61,7 @@
       </svelte:fragment>
     </Modal>
   {:else if form == 'basic'}
-    <Modal bind:this={modal} scrollable>
+    <Modal bind:this={modal} {dropdownLinkTrigger} openHelpDropdownOnModalClose scrollable>
       <svelte:fragment slot="title">Questions?</svelte:fragment>
       <svelte:fragment slot="body">
         {#if winterBreak}<p>{@html message}</p>{/if}
@@ -74,7 +69,7 @@
       </svelte:fragment>
     </Modal>
   {:else}
-    <Modal bind:this={modal} scrollable>
+    <Modal bind:this={modal} {dropdownLinkTrigger} openHelpDropdownOnModalClose scrollable>
       <svelte:fragment slot="title">Questions?</svelte:fragment>
       <svelte:fragment slot="body">
         {#if winterBreak}<p>{@html message}</p>{/if}

--- a/src/js/components/Modal/index.svelte
+++ b/src/js/components/Modal/index.svelte
@@ -12,6 +12,8 @@
   export let mode = 'alert';
   export let modalLarge = false;
   export let fullscreenOnMobile = false;
+  export let openHelpDropdownOnModalClose = false;
+  export let dropdownLinkTrigger;
 
   let modalBody;
 
@@ -28,7 +30,15 @@
     // })
   };
 
-  export const hide = function () {
+  function showHelpDropdown() {
+    document.querySelector('#get-help').classList.add('show');
+    document.querySelector('#get-help + ul').classList.add('show');
+    document.querySelector('#get-help + ul').classList.remove('d-block');
+    document.querySelector('#get-help + ul').setAttribute('data-bs-popper', 'static');
+    dropdownLinkTrigger.focus();
+  }
+
+  export const hide = function (e) {
     if (!dialog) {
       return;
     } // rare edge case
@@ -39,6 +49,12 @@
     isOpen = false;
     onClose();
     console.log('-- dialog is closed');
+
+    if (openHelpDropdownOnModalClose) {
+      if (e.detail === 0) {
+        setTimeout(showHelpDropdown);
+      }
+    }
   };
 
   onMount(() => {
@@ -79,8 +95,8 @@
             class="btn btn-sm btn-outline-secondary d-flex align-items-center gap-2 justify-between order-1 ms-auto text-uppercase"
             aria-label="Close Modal"
             data-bs-dismiss="modal"
-            on:click={() => {
-              hide();
+            on:click={(e) => {
+              hide(e);
             }}>Close <i class="fa-solid fa-xmark" aria-hidden="true" /></button
           >
         </div>

--- a/src/js/components/Modal/index.svelte
+++ b/src/js/components/Modal/index.svelte
@@ -12,8 +12,7 @@
   export let mode = 'alert';
   export let modalLarge = false;
   export let fullscreenOnMobile = false;
-  export let openHelpDropdownOnModalClose = false;
-  export let dropdownLinkTrigger;
+  export let focusHelpOnClose = false;
 
   let modalBody;
 
@@ -25,20 +24,9 @@
     }
     isOpen = true;
     dialog.showModal();
-    // setTimeout(() => {
-    //   dialog.querySelector('button').focus();
-    // })
   };
 
-  function showHelpDropdown() {
-    document.querySelector('#get-help').classList.add('show');
-    document.querySelector('#get-help + ul').classList.add('show');
-    document.querySelector('#get-help + ul').classList.remove('d-block');
-    document.querySelector('#get-help + ul').setAttribute('data-bs-popper', 'static');
-    dropdownLinkTrigger.focus();
-  }
-
-  export const hide = function (e) {
+  export const hide = function () {
     if (!dialog) {
       return;
     } // rare edge case
@@ -50,10 +38,8 @@
     onClose();
     console.log('-- dialog is closed');
 
-    if (openHelpDropdownOnModalClose) {
-      if (e.detail === 0) {
-        setTimeout(showHelpDropdown);
-      }
+    if (focusHelpOnClose) {
+      document.getElementById('get-help').focus();
     }
   };
 
@@ -95,8 +81,8 @@
             class="btn btn-sm btn-outline-secondary d-flex align-items-center gap-2 justify-between order-1 ms-auto text-uppercase"
             aria-label="Close Modal"
             data-bs-dismiss="modal"
-            on:click={(e) => {
-              hide(e);
+            on:click={() => {
+              hide();
             }}>Close <i class="fa-solid fa-xmark" aria-hidden="true" /></button
           >
         </div>

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -13,6 +13,7 @@
   let feedbackModal;
   let location = document.documentElement.dataset.app;
   let form = 'basic';
+  let dropdownLinkTrigger;
 
   let notificationsModal;
   let notificationsManager = new NotificationsManager({
@@ -53,7 +54,16 @@
     }
   }
 
-  function openFeedback(formLocation) {
+  function feedbackModalFocusHandler(e) {
+    //e.detail of 0 is a keyobard "click"
+    if (e.detail === 0) {
+      document.querySelector('#get-help + ul').classList.add('d-block');
+      document.querySelector('#get-help + ul').setAttribute('data-bs-popper', 'static');
+      dropdownLinkTrigger = e.target;
+    }
+  }
+
+  function openFeedback(e, formLocation) {
     if (formLocation === 'catalog') {
       form = 'catalog';
     } else if (formLocation === 'pt') {
@@ -64,6 +74,7 @@
       form = 'basic';
     }
     feedbackModal.show();
+    feedbackModalFocusHandler(e);
   }
 
   function checkSwitchableRoles(isLoggedIn) {
@@ -93,7 +104,7 @@
   }
 </script>
 
-<FeedbackFormModal {form} bind:this={feedbackModal} />
+<FeedbackFormModal {form} {dropdownLinkTrigger} bind:this={feedbackModal} />
 <nav class="navbar navbar-expand-xl bg-white">
   <div class="container-fluid">
     <div class="ht-logo" class:compact>
@@ -319,6 +330,7 @@
           <a
             href="#"
             role="button"
+            id="get-help"
             aria-expanded="false"
             class="nav-link dropdown-toggle text-uppercase d-flex flex-row justify-content-between align-items-center gap-2"
             data-bs-toggle="dropdown"
@@ -338,8 +350,9 @@
               <li class="px-3">
                 <a
                   href="#"
+                  id="ask-a-question"
                   class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                  on:click|preventDefault={() => openFeedback('questions')}
+                  on:click|preventDefault={(e) => openFeedback(e, 'questions')}
                 >
                   <span>Ask a Question</span>
                   <i class="fa-regular fa-circle-question" />
@@ -348,8 +361,9 @@
               <li class="px-3">
                 <a
                   href="#"
+                  id="report-a-problem"
                   class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                  on:click|preventDefault={() => openFeedback(location)}
+                  on:click|preventDefault={(e) => openFeedback(e, location)}
                 >
                   <span>Report a Problem</span>
                   <i class="fa-solid fa-bug" />
@@ -621,6 +635,7 @@
     --bs-dropdown-link-color: var(--color-neutral-800);
     --bs-dropdown-link-hover-color: var(--color-netural-800);
     --bs-dropdown-link-hover-bg: var(--color-neutral-50);
+
     div {
       padding-top: 0.5rem;
       @media (min-width: 1200px) {

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -13,7 +13,6 @@
   let feedbackModal;
   let location = document.documentElement.dataset.app;
   let form = 'basic';
-  let dropdownLinkTrigger;
 
   let notificationsModal;
   let notificationsManager = new NotificationsManager({
@@ -54,16 +53,7 @@
     }
   }
 
-  function feedbackModalFocusHandler(e) {
-    //e.detail of 0 is a keyobard "click"
-    if (e.detail === 0) {
-      document.querySelector('#get-help + ul').classList.add('d-block');
-      document.querySelector('#get-help + ul').setAttribute('data-bs-popper', 'static');
-      dropdownLinkTrigger = e.target;
-    }
-  }
-
-  function openFeedback(e, formLocation) {
+  function openFeedback(formLocation) {
     if (formLocation === 'catalog') {
       form = 'catalog';
     } else if (formLocation === 'pt') {
@@ -74,7 +64,6 @@
       form = 'basic';
     }
     feedbackModal.show();
-    feedbackModalFocusHandler(e);
   }
 
   function checkSwitchableRoles(isLoggedIn) {
@@ -104,7 +93,7 @@
   }
 </script>
 
-<FeedbackFormModal {form} {dropdownLinkTrigger} bind:this={feedbackModal} />
+<FeedbackFormModal {form} bind:this={feedbackModal} />
 <nav class="navbar navbar-expand-xl bg-white">
   <div class="container-fluid">
     <div class="ht-logo" class:compact>
@@ -352,7 +341,7 @@
                   href="#"
                   id="ask-a-question"
                   class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                  on:click|preventDefault={(e) => openFeedback(e, 'questions')}
+                  on:click|preventDefault={() => openFeedback('questions')}
                 >
                   <span>Ask a Question</span>
                   <i class="fa-regular fa-circle-question" />
@@ -363,7 +352,7 @@
                   href="#"
                   id="report-a-problem"
                   class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                  on:click|preventDefault={(e) => openFeedback(e, location)}
+                  on:click|preventDefault={() => openFeedback(location)}
                 >
                   <span>Report a Problem</span>
                   <i class="fa-solid fa-bug" />


### PR DESCRIPTION
The last couple fixes for the feedback form and feedback modal

## issue [1727230](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/c5c9a642-fe25-11ee-a00b-d7cff31345ee?sortField=severity&sortDir=desc&page=0&issuesCount=&filter%5Bcomponent_number%5D=1&row=1): identify input purpose missing for name and email

All three feedback forms were missing "autocomplete" HTML attributes on name and email fields, so I added them. See `FeedbackFormBasic/index.svelte`, `FeedbackFormCatalog/index.svelte`, and `FeedbackFormContent/index.svelte`.

To test: on [dev-3](https://dev-3.www.hathitrust.org/), open the feedback form using the GET HELP dropdown in the navbar. Use dev tools to inspect the name input element and see the autocomplete attribute set to "name". The email input element has the autocomplete attribute set to "email".

## issue [1727229](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/81c6ae40-fe25-11ee-aa61-97d2fe293477?sortField=severity&sortDir=desc&page=0&issuesCount=&filter%5Bcomponent_number%5D=1&row=4): when modal is closed, focus isn't returned to trigger

When any modal is closed, in order to remain accessible, the browser/user's focus should be returned to the element that triggered the opening of the modal. In this case, the triggering element is in the navbar dropdown under GET HELP. The feedback form opens when a user clicks "Ask a Question" or "Report a Problem." I originally fixed this so that the focus would return to either of those links, but the fix included not-best-practices javascript in order to reopen the dropdown that would normally close on-click. Deque says it's fine to return the focus to the dropdown link element (GET HELP) instead of the _actual_ triggering element, so I undid all that junk and did something much simpler: added a boolean prop `focusHelpOnClose` to the FeedbackFormModal component to pass down to the Modal component. If that value is `true`, the focus is returned to GET HELP when the modal is closed.

To test: on [dev-3](https://dev-3.www.hathitrust.org/) (or locally if you want to pull down the branch), use your keyboard to navigate through the navbar to "GET HELP." Hit enter to toggle the dropdown, then select either of the feedback forms. The dropdown should close, a modal should open. Now hit enter again to close the modal (the close button should be auto-focused), and see that the focus ring returns to the GELP HELP link. You can also check that the login modal has similar behavior.