### PR TITLE
issue #89: add event listener for escape key

### DIFF
--- a/src/js/components/Modal/index.svelte
+++ b/src/js/components/Modal/index.svelte
@@ -18,12 +18,23 @@
 
   let dialog;
 
+  function logKeys(e) {
+    console.log(`Key "${e.key}" was pressed`);
+    if (e.key === 'Escape') {
+      hide();
+      window.removeEventListener('keydown', logKeys);
+    }
+  }
+
   export const show = function () {
     if (dialog.open) {
       return;
     }
     isOpen = true;
     dialog.showModal();
+    if (focusHelpOnClose) {
+      window.addEventListener('keydown', logKeys);
+    }
   };
 
   export const hide = function () {
@@ -36,6 +47,7 @@
     dialog.close();
     isOpen = false;
     onClose();
+    window.removeEventListener('keydown', logKeys);
     console.log('-- dialog is closed');
 
     if (focusHelpOnClose) {
@@ -70,7 +82,7 @@
   class={fullscreenOnMobile ? 'fullscreen-sm-down' : ''}
 >
   <div class="modal show" aria-labelledby="{id}-label" style="display: block;">
-    <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered {modalLarge ? 'modal-lg' : ''} ">
+    <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered {modalLarge ? 'modal-lg' : ''}">
       <div class="modal-content" style:height={height != 'auto' && height}>
         <div class="modal-header">
           <h1 id="{id}-label" class="modal-title">

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -54,6 +54,7 @@
   }
 
   function openFeedback(formLocation) {
+    if (document.activeElement !== document.getElementById('get-help')) document.getElementById('get-help').focus();
     if (formLocation === 'catalog') {
       form = 'catalog';
     } else if (formLocation === 'pt') {


### PR DESCRIPTION
Re: @mwarin's suggestion in PR #88 

> 1: As a user relying on keyboard/screen-reader, I think it would be neat if the form modal would close on ESC, rather than having to tab back to the beginning of the form to close it. This might be accessibility-heresy, so take that as the personal preference it is.

I did some testing and found an additional bug: my original fix returned the focus to the GET HELP link when you use the CLOSE button on the modal, but the `ESC` key returned the focus back to the body element. 

This event listener (with a few `.focus()` methods thrown in for fallback/good measure) picks up on `ESC` keys and invokes the `hide()` function (which sets the focus back to GET HELP).

This closes issue #89.

**To test:** head over to [dev-3](https://dev-3.www.hathitrust.org/) and tab through the nav menu to GET HELP. Select with ENTER and tab down to Ask a Question. Hit ENTER again to open the modal. Hit ESC to close modal. Focus should be returned to GET HELP in navbar. If you tab through some fields in the form, you have to hit ESC to exit the form field, then ESC again should close the modal and return focus to GET HELP.