### PR TITLE
#92: focus indicator bug fixes

### DIFF
--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -99,7 +99,7 @@
   <div class="container-fluid">
     <div class="ht-logo" class:compact>
       <!-- <img src="../assets/HT-logo-mobile-nav.svg" alt="HathiTrust" class="" /> -->
-      <a href="//{HT.www_domain}/">
+      <a href="//{HT.www_domain}/" class="d-block">
         <svg
           aria-labelledby="ht-logo-title"
           role="img"

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -351,7 +351,7 @@ body[data-initialized='true'] {
 }
 
 // FOCUS STYLES
-.btn, .accordion .accordion-button, select.form-select, input.form-control, textarea.form-control, input.form-check-input, :is(.was-validated) :is(.form-control, .form-select, .form-check-input) {
+.btn, .btn.active, .accordion .accordion-button, select.form-select, input.form-control, textarea.form-control, input.form-check-input, :is(.was-validated) :is(.form-control, .form-select, .form-check-input) {
   &:focus-visible {
       outline: 3px solid #086AB4 !important;
       outline-offset: 4px;

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -88,6 +88,7 @@ $ht-focus-box-shadow: 0 0 0 6px #fff;
   box-shadow: 0 0 0 6px #fff;
   outline-offset: 4px;
   z-index: 3;
+  transition: unset;
 }
 
 // Required
@@ -351,12 +352,13 @@ body[data-initialized='true'] {
 }
 
 // FOCUS STYLES
-.btn, .btn.active, .accordion .accordion-button, select.form-select, input.form-control, textarea.form-control, input.form-check-input, :is(.was-validated) :is(.form-control, .form-select, .form-check-input) {
+.btn, .btn.active, .nav-link, .accordion .accordion-button, select.form-select, input.form-control, textarea.form-control, input.form-check-input, :is(.was-validated) :is(.form-control, .form-select, .form-check-input) {
   &:focus-visible {
       outline: 3px solid #086AB4 !important;
       outline-offset: 4px;
       box-shadow: 0 0 0 6px white;
       z-index: 3;
+      transition: unset;
     }
     &:focus {
       outline: 3px solid transparent;


### PR DESCRIPTION
## website logo focus indicator

The navbar logo had a visible focus indicator in the apps but not on the website. The element received focus without issue, but there was no visible focus indicator. I changed the display to `block` instead of `inline` and that fixed the issue.

## "active" button focus indicator style

I missed that we use the "active" class on some buttons (the ones that came up during testing are in page turner, but they may be elsewhere, too!). "active" buttons had their own focus styles from bootstrap, so I overrode those.

## remove animations on focus

The animations that are triggered on focus are not consistent and are a little distracting. I set `transition: unset` in all of our focus state styles to remove animations on focus.

## to test
- Hop on your VPN and head over to https://dev-3.www.hathitrust.org/. Tab through to the navbar logo and see the blue focus indicator. 
- Pick any item in page turner. Maybe the [jello book](https://dev-3.babel.hathitrust.org/cgi/pt?id=uc1.31822031022254&seq=1) from the website launch? Open the "Search in this Text" accordion and search for 'jello'. Use your keyboard to tab down to the search sorting options. The two gray buttons have an "active" class applied, and when you tab over them, you should see a blue outside ring with a white inside ring around the gray button.
- There isn't a very good way to test the lack of animation on the focus styles.  You can tab around and see if the blue ring slowly (300ms isn't really _slow_ but it kind of is compared to 0ms) fades in or not. Based on my testing, there is still animation on the colors of the text and background of buttons and links, but that's supposed to be like that. It's pretty subtle, so don't worry about testing this, really.
