### PR TITLE
DEV-1175/#91: Reflow issues

### DIFF
--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -495,7 +495,7 @@
           {#if idx > 0}
             <fieldset class="mb-3">
               <legend class="visually-hidden">Boolean operator for field {idx} and field {idx + 1}</legend>
-              <div class="d-flex gap-3 align-items-center justify-content-start">
+              <div class="d-flex gap-3 align-items-center justify-content-center justify-content-sm-start">
                 {#each booleanOptions as option, bidx}
                   <div class="form-check">
                     <input
@@ -513,9 +513,9 @@
               </div>
             </fieldset>
           {/if}
-          <fieldset class="search-clause mb-3 border border-dark rounded">
-            <div class="d-flex">
-              <legend class="visually-hidden">Search Field {idx + 1}</legend>
+          <fieldset class="search-clause mb-3">
+            <legend class="visually-hidden">Search field {idx + 1}:</legend>
+            <div class="field-container d-flex search-field border border-dark rounded">
               <div class="select-container border border-0 flex-grow-1">
                 <select
                   class="form-select rounded-0 rounded-start"
@@ -601,7 +601,7 @@
               Publication Year must be between 0-9999.
             </div>
           {/if}
-          <div class="d-flex gap-3 mb-1">
+          <div class="d-flex gap-3 mb-1 flex-wrap">
             {#each yopOptions as option, yidx}
               <div class="form-check">
                 <input
@@ -727,10 +727,21 @@
       margin-left: 0;
     }
   }
-  @media (max-width: 25rem) {
-    .form-select,
-    .form-control {
-      font-size: 0.875rem;
+  @media (max-width: 36rem) {
+    .field-container {
+      border:none !important;
+    }
+    .search-field {
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    .select-container select {
+      border: 1px solid var(--color-neutral-500) !important;
+      border-radius: 0.375rem !important;
+    }
+    .search-input .form-control {
+      border: 1px solid var(--color-neutral-500) !important;
+      border-radius: 0.375rem !important;
     }
   }
 </style>

--- a/src/js/components/AdvancedSearchForm/index.svelte
+++ b/src/js/components/AdvancedSearchForm/index.svelte
@@ -727,4 +727,10 @@
       margin-left: 0;
     }
   }
+  @media (max-width: 25rem) {
+    .form-select,
+    .form-control {
+      font-size: 0.875rem;
+    }
+  }
 </style>

--- a/src/js/components/CookieConsentBanner/index.svelte
+++ b/src/js/components/CookieConsentBanner/index.svelte
@@ -150,7 +150,14 @@
     border-end-start-radius: 0;
     background: var(--color-primary-200);
     padding: 1.25rem 1rem;
+<<<<<<< HEAD
     max-height: 34rem;
+=======
+    // max-height: 34rem;
+    max-height: 80vh;
+    overflow-y: scroll;
+
+>>>>>>> 12b2702 (restrict max height, add scroll for overflow)
     .h2 {
       font-size: 1.25rem;
       line-height: 120%; /* 1.5rem */

--- a/src/js/components/CookieConsentBanner/index.svelte
+++ b/src/js/components/CookieConsentBanner/index.svelte
@@ -150,14 +150,10 @@
     border-end-start-radius: 0;
     background: var(--color-primary-200);
     padding: 1.25rem 1rem;
-<<<<<<< HEAD
-    max-height: 34rem;
-=======
     // max-height: 34rem;
     max-height: 80vh;
     overflow-y: scroll;
 
->>>>>>> 12b2702 (restrict max height, add scroll for overflow)
     .h2 {
       font-size: 1.25rem;
       line-height: 120%; /* 1.5rem */


### PR DESCRIPTION
## [1727499](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/1cbfa3da-fe3e-11ee-a1dd-3b59689c7f4e?sortField=ordinal&sortDir=asc&filter%5Bstatus%5D=open&row=1) / DEV-1175

This issue occurred in Advanced Search. Turns out there were _multiple_ reflow issues. The issue flagged by deque is only that the placeholder text in the search input field was cut off when zoomed in. It needs to be fully visible.

Issue:

![image](https://github.com/user-attachments/assets/0f09ef8e-33c0-498f-aab4-cb1cadb028d0)

What we learned as I starting debugging this is that the input fields should've started wrapping but they couldn't because a single element later in the page was set to `nowrap` which caused other elements to not collapse when they should've. [Video link for posterity.](https://hathitrust.slack.com/files/U044M495QEN/F07G7QRRHAQ/screenshare_-_2024-08-08_2_52_07_pm.webm)

@giramesh designed a mobile view for the main search fields and flexbox made it easy to change those without rearranging the markup.

On dev-3 at 400%:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7ba4bb9d-deca-47e3-860c-9d3e39d86c40">


**To test:** Go to [dev-3 advanced search page](https://dev-3.babel.hathitrust.org/cgi/ls?a=page&page=advanced) and zoom your browser in to 400%. Verify that you can read all the fields and that none of the UI elements are hidden behind a horizontal scroll.

## [1728469](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/6802e884-0078-11ef-9e6f-2f55729b43ab?searchKeyword=1728469&searchOn=id&sortField=ordinal&sortDir=asc&row=0) and [1728474](https://axeauditor.dequecloud.com/test-run/b2613a94-fe0b-11ee-96ce-dfcb37e53e3c/issue/df8595d2-0078-11ef-a2d7-831ce1b084e9?searchKeyword=1728474&searchOn=id&sortField=ordinal&sortDir=asc&row=0)

These issues are related to the cookie consent banner. At 400%, the content of the cookie banner takes up the whole screen and you can't read some of the content and/or see/use the close button.
 
The banner on my browser at 400%:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/1d6639ec-9114-4457-ae71-7a1260a15f3a">


I changed the `max-height` of the banner from a static-ish `rem` value to a percentage of the viewport height: `80vh`. This caps the height of the cookie banner to 80% of the viewport height. I also added a scroll for the overflow of that content.

The banner on dev-3 at 400%:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8c8fda76-d3e6-40a8-ad63-d84f7b01177b">


**To test:** anywhere on dev-3 (you might need to clear your cookies to see the banner again), zoom your browser in to 400%. Verify that you can see all the content, even if it requires scrolling on the cookie banner to get to the buttons at the bottom of the banner.

closes issue #91 