### PR TITLE
fix form field focus styles

### DIFF
--- a/src/js/components/CollectionsToolbar/index.svelte
+++ b/src/js/components/CollectionsToolbar/index.svelte
@@ -347,4 +347,7 @@
 <CollectionEditModal bind:this={modal} {userIsAnonymous} {c} {cn} {desc} {contributorName} {shared} {submitAction} />
 
 <style>
+  .bg-secondary button:not(.dropdown-item):focus-visible, .bg-secondary .form-select:focus-visible {
+    outline-offset:0;
+  }
 </style>

--- a/src/js/components/CollectionsToolbar/index.svelte
+++ b/src/js/components/CollectionsToolbar/index.svelte
@@ -350,4 +350,7 @@
   .bg-secondary button:not(.dropdown-item):focus-visible, .bg-secondary .form-select:focus-visible {
     outline-offset:0;
   }
+  .form-select:focus {
+    border-color: transparent;
+  }
 </style>

--- a/src/js/components/CollectionsToolbar/index.svelte
+++ b/src/js/components/CollectionsToolbar/index.svelte
@@ -347,10 +347,4 @@
 <CollectionEditModal bind:this={modal} {userIsAnonymous} {c} {cn} {desc} {contributorName} {shared} {submitAction} />
 
 <style>
-  .bg-secondary button:not(.dropdown-item):focus-visible, .bg-secondary .form-select:focus-visible {
-    outline-offset:0;
-  }
-  .form-select:focus {
-    border-color: transparent;
-  }
 </style>

--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -312,6 +312,9 @@ body {
       border-bottom-right-radius: 0.375rem;
     }
   }
+  #toolbar-seq.form-control:focus {
+    border-color: #fff;
+  }
 }
 
 span.query-term {

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -371,13 +371,12 @@ a:focus-visible {
 .bg-secondary button:not(.dropdown-item):focus-visible, .bg-secondary .form-select:focus-visible, .bg-dark .form-control:focus-visible {
   outline-offset:0;
 }
-.form-select:focus, .form-control:focus {
-  border-color: transparent;
-}
 
 
 .form-check-input, .form-control, .form-select {
+  &:focus {
   border: 1px solid var(--color-neutral-500);
+  }
 }
 input.form-control[type],
 textarea.form-control {

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -368,6 +368,14 @@ a:focus-visible {
   border-radius: 6px;
 }
 
+.bg-secondary button:not(.dropdown-item):focus-visible, .bg-secondary .form-select:focus-visible, .bg-dark .form-control:focus-visible {
+  outline-offset:0;
+}
+.form-select:focus, .form-control:focus {
+  border-color: transparent;
+}
+
+
 .form-check-input, .form-control, .form-select {
   border: 1px solid var(--color-neutral-500);
 }


### PR DESCRIPTION
This is only an issue for elements with a `bg-secondary` or `bg-dark` utility class. Our focus blue doesn't have enough contrast against the dark gray or black, so Gayathri and I decided to flip the blue and white of the universal focus style, but only for these components.

Previous:
<img width="198" alt="image" src="https://github.com/user-attachments/assets/df92a645-5761-4cb8-956d-19a4d3f17264">

With this update:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ee876d45-fffe-4ca1-86fa-fe0c554fa913">

Black toolbar element in page turner:
<img width="138" alt="image" src="https://github.com/user-attachments/assets/869836f1-bae9-4e05-a222-063a98f4debe">

With this fix:
<img width="121" alt="image" src="https://github.com/user-attachments/assets/a65f87e8-1fbe-4960-abcf-ff21a20287a9">

And removes this bootstrap bleed through focus style with an orange outline (all form elements, not just dropdown/selects):
<img width="192" alt="image" src="https://github.com/user-attachments/assets/f22e2287-da15-4218-b7f4-937d073722b8">

Updated:
<img width="213" alt="image" src="https://github.com/user-attachments/assets/f0d66b9e-2539-48f5-a8fd-e77419b321b5">

@giramesh, does this look good to you on dev-3?
