### PR TITLE
add cyan to utility classes

### DIFF
--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -161,6 +161,7 @@ $utilities: map-merge(
             'neutral-200': $ht-color-neutral-200,
             'neutral-800': $ht-color-neutral-800,
             'neutral-900': $ht-color-neutral-900,
+            'cyan-700': $cyan-700,
             'muted': $text-muted,
             // deprecated
             'black-50': rgba($black, 0.5),


### PR DESCRIPTION
For the TIFF restrictions note in [babel PR 46](https://github.com/hathitrust/babel/pull/46), we need to add the bootstrap `cyan-700` shade to our utility class list of text colors.