### PR TITLE
DEV-1292: remove youtube language from cookie settings modal

### DIFF
--- a/src/js/components/CookieSettingsModal/index.svelte
+++ b/src/js/components/CookieSettingsModal/index.svelte
@@ -212,7 +212,7 @@
                     <div id="collapse4" class="accordion-collapse collapse" aria-labelledby="heading4">
                       <div class="accordion-body">
                         <p id="marketing-description">
-                          Our website enables limited YouTube and Google marketing cookies.
+                          Our website enables limited Google marketing cookies.
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
Like it says on the tin, I removed "YouTube" from the content of the cookie modal.

Staged on dev-3 if you want to take a look: [dev-3.www.hathitrust.org](https://dev-3.www.hathitrust.org/)

If you get the cookie banner, you can click on "Customize cookies >" to get the modal, but if you've accepted cookies on dev-3 recently, you can scroll down to the footer and select "Cookie Settings". Then open the "Marketing" accordion to see that the content has been updated.