### PR TITLE
DEV-900: add 'original location' filter to advanced search

### DIFF
--- a/src/js/components/FilterableSelection.svelte
+++ b/src/js/components/FilterableSelection.svelte
@@ -123,7 +123,7 @@
             on:focus={(event) => updateValue(event, true)}
           />
         {/if}
-        <label class="form-check-label p-2 px-3" for="item{index}-{guid}">{item.option}</label>
+        <label class="form-check-label p-2 px-3" for="item{index}-{guid}">{@html item.option}</label>
       </li>
     {/each}
   </ul>


### PR DESCRIPTION
related to hathitrust/babel#70 and hathitrust/catalog#65 

This adds an "Original Location" filter option to the advanced search component. 

See this in action on dev-3 [catalog](https://dev-3.catalog.hathitrust.org/Search/Advanced) and [ls](https://dev-3.babel.hathitrust.org/cgi/ls?a=page&page=advanced) (vpn required).

## `FilterableSelection` component
I added another `FilterableSelection` component to match the 'Language' and 'Format' selection options. This version, however, sets the 'multiple' prop to `false` because selecting two locations did not work in either `catalog` or `ls`.

## search parameters
I updated the functions for `catalog` and `ls` search URLs. The form itself is identical, but the URLs for searching in `catalog` and `ls` have slight differences. I added functions for appending an `htsource` facet/filter to the search parameters. There is also some logic in the `onMount()` hook that checks if there are existing search parameters when the page is loaded (in case the user clicked 'Revise this advanced search' from the search results page) so that those options are pre-filled/pre-selected in the form. I added some conditionals for original location for both `catalog` and `ls` that updates the component with that value from the URL.

## testing

Things you could test:
- multiple search terms with a location selected
- multiple languages with location selected
- `*` as search term with location selected (to see all items from that location)
- click the “revise this advanced search” button (in both catalog and ls views) to make sure all facets are retained (this is annoying to do with the FilterableSelection components, but we will be addressing this in the future)