### PR TITLE
DEV-1116: update staging links utility

### DIFF
--- a/src/js/lib/staging.js
+++ b/src/js/lib/staging.js
@@ -13,11 +13,12 @@ function mungeLink(href) {
     var tmp = href.split('?');
     href = tmp[0].replace('//hdl.handle.net/2027/', '//' + HT.service_domain + '/cgi/pt?id=');
     if (tmp[1]) {
-      var tmp2 = tmp[1].split('=');
-      if (tmp2[1].includes('%3B')) {
-        let tmp3 = tmp2[1].split('%3B');
-        href += ';' + tmp3[1] + '=' + tmp2[2];
+      if (tmp[1].includes('urlappend=')) {
+        let querystring = tmp[1].replaceAll('%3B', ';')
+        querystring = querystring.replace('urlappend=', '')
+        href += querystring
       } else {
+        var tmp2 = tmp[1].split('=');
         href += ';seq=' + tmp2[2];
       }
     }

--- a/src/js/lib/staging.js
+++ b/src/js/lib/staging.js
@@ -14,7 +14,12 @@ function mungeLink(href) {
     href = tmp[0].replace('//hdl.handle.net/2027/', '//' + HT.service_domain + '/cgi/pt?id=');
     if (tmp[1]) {
       var tmp2 = tmp[1].split('=');
-      href += ';seq=' + tmp2[2];
+      if (tmp2[1].includes('%3B')) {
+        let tmp3 = tmp2[1].split('%3B');
+        href += ';' + tmp3[1] + '=' + tmp2[2];
+      } else {
+        href += ';seq=' + tmp2[2];
+      }
     }
   }
   return href.replace('https:', location.protocol);


### PR DESCRIPTION
This handy/wild staging utility rewrites links on dev servers to match the subdomain/protocol of the server. When I was removing the cookie banner from pt embeds (DEV-1116), something weird was happening with rewriting the handle URLs for the iframe. Aaron helped me track down this function, and I refactored to make it a bit more robust.

I kept the original if statement but nested it inside another if statement (🫠) just in case it's necessary for something that I am unaware of.

This might not be the best code in the world, but it doesn't affect prod and I needed to add this to stage the work for hathitrust/babel#73

To test: The pt embed iframes are now loading correctly with the minimal UI look. This code isn't staged on the test server yet, so the old function is still causing the iframes on the [embed page](https://test.www.hathitrust.org/member-libraries/resources-for-librarians/improve-discovery/embed-hathitrust-books/) to use the full UI (navbar, "options" menu, page toolbar), but the [dev-3 embed page](https://dev-3.www.hathitrust.org/member-libraries/resources-for-librarians/improve-discovery/embed-hathitrust-books/) has the correct "minimal" UI (like prod).