### PR TITLE
DEV-1095: Outage notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ or something like that.
 
 a.k.a. Outage Notifications
 
-This is the data for outage notification alert banners. We will update the adjacent `alert.json` file when a notification should be deployed site-wide. This file will typically be empty, but will include the data (as shown in the exmample below) when a notification is needed.
+This is the data for outage notification alert banners. We will update `/alerts/alert.json` when a notification should be deployed site-wide. This file will typically be empty, but will include the data (as shown in the exmample below) when a notification is needed.
 
 ## Alert types
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 * [Hosting](#hosting---todo)
 * [Resources](#resources---todo)
 * [Configuration](#configuration)
+* [Alerts](#alerts)
 * [`ping`](#on-accessing-ping)
 
 ## About
@@ -148,6 +149,37 @@ or something like that.
   * `HT.catalog_domain`
   * `HT.www_domain`
   * `HT.cookies_domain`
+
+## Alerts
+
+a.k.a. Outage Notifications
+
+This is the data for outage notification alert banners. We will update the adjacent `alert.json` file when a notification should be deployed site-wide. This file will typically be empty, but will include the data (as shown in the exmample below) when a notification is needed.
+
+## Alert types
+
+### Default alert
+
+This alert includes a title and all other details.
+
+### Simple alert
+
+This alert does not include a title. It should still include a 'type' and 'link'/'linkText'. The title should be an empty string, e.g. `"title": "",`
+
+## Example
+
+**Note:** The `id` should be unique to each alert because a cookie with the related ID is created when the banner is dismissed.
+
+```json
+{
+    "title": "Outage: Incomplete search results",
+    "message": "Users searching within the full text of all volumes will receive incomplete search results.",
+    "link": "https://www.hathitrust.org/press-post/outage-incomplete-search-results/",
+    "linkText": "See updates here",
+    "type": "danger",
+    "id": 20250219,
+}
+```
 
 ## On accessing `ping`
 

--- a/src/js/components/AlertBanner/AlertBanner.stories.js
+++ b/src/js/components/AlertBanner/AlertBanner.stories.js
@@ -1,9 +1,9 @@
-import AlertBanner from './index.svelte'
+import BannerMessage from './BannerMessage.svelte'
 import PingCallbackDecorator from '../../decorators/PingCallbackDecorator';
 
 export default {
     title: 'Alert Banner',
-    component: AlertBanner,
+    component: BannerMessage,
 }
 
 const parameters = {

--- a/src/js/components/AlertBanner/AlertBanner.stories.js
+++ b/src/js/components/AlertBanner/AlertBanner.stories.js
@@ -27,6 +27,21 @@ export const Warning = {
   ],
 }
 
+export const Brand = {
+  parameters: parameters, 
+  args: {
+    type: 'brand',
+    title: `Update: Thanks for being awesome!`,
+    message: `We're having problems with our website and applications right now. Please be patient while we fix it. Thanks!`
+  },
+  decorators: [
+    () => ({
+      //ping here for cookie handling
+      Component: PingCallbackDecorator,
+    }),
+  ],
+}
+
 export const Danger = {
   parameters: parameters, 
   args: {

--- a/src/js/components/AlertBanner/AlertBanner.stories.js
+++ b/src/js/components/AlertBanner/AlertBanner.stories.js
@@ -6,16 +6,91 @@ export default {
     component: AlertBanner,
 }
 
-export const Default = {
-   parameters: {
-    viewport: {
-      defaultViewport: 'bsLg',
-    },
-  }, 
+const parameters = {
+  viewport: {
+    defaultViewport: 'bsLg',
+  },
+};
+
+export const Warning = {
+  parameters: parameters, 
+  args: {
+    type: 'warning',
+    title: `Outage: Ongoing website issues`,
+    message: `We're having problems with our website and applications right now. Please be patient while we fix it. Thanks!`
+  },
   decorators: [
     () => ({
+      //ping here for cookie handling
       Component: PingCallbackDecorator,
-      // props: { loggedIn: true },
+    }),
+  ],
+}
+
+export const Danger = {
+  parameters: parameters, 
+  args: {
+    type: 'danger',
+    title: `Outage: Ongoing website issues`,
+    message: `We're having problems with our website and applications right now. Please be patient while we fix it. Thanks!`
+  },
+  decorators: [
+    () => ({
+      //ping here for cookie handling
+      Component: PingCallbackDecorator,
+    }),
+  ],
+}
+
+export const DangerMobile = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'bsXs',
+    },
+  }, 
+  args: {
+    type: 'danger',
+    title: `Outage: Ongoing website issues`,
+    message: `We're having problems with our website and applications right now. Please be patient while we fix it. Thanks!`
+  },
+  decorators: [
+    () => ({
+      //ping here for cookie handling
+      Component: PingCallbackDecorator,
+    }),
+  ],
+}
+
+export const MessageOnly = {
+  parameters: parameters, 
+  args: {
+    type: 'warning',
+    title: '',
+    message: `Some parts of the HathiTrust website is experiencing intermittent access issues. We are monitoring this issue.`
+  },
+  decorators: [
+    () => ({
+      //ping here for cookie handling
+      Component: PingCallbackDecorator,
+    }),
+  ],
+}
+
+export const MessageOnlyMobile = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'bsXs',
+    },
+  }, 
+  args: {
+    type: 'danger',
+    title: '',
+    message: `We're having problems with our website and applications right now. Please be patient while we fix it. Thanks!`
+  },
+  decorators: [
+    () => ({
+      //ping here for cookie handling
+      Component: PingCallbackDecorator,
     }),
   ],
 }

--- a/src/js/components/AlertBanner/BannerMessage.svelte
+++ b/src/js/components/AlertBanner/BannerMessage.svelte
@@ -1,0 +1,157 @@
+<script>
+  let HT = window.HT || {};
+  let cookieJar = HT.cookieJar;
+  import { preferencesConsent } from '../../lib/store';
+
+  //   export let title = 'Outage: Website is down';
+  export let title = '';
+  export let message = `We're experiencing technical difficulties with our site and applications. Thank you for your patience!`;
+  export let link = 'https://www.hathitrust.org/press-post/outage-incomplete-search-results/';
+  export let linkText = 'See updates here';
+  export let type = 'warning';
+  //ID should increment with each new alert
+  export let id = 1;
+
+  let isVisible = true;
+
+  export function closeAlert() {
+    //if user has functional/preference cookies enabled, set a 14-day cookie to remember dismissed preference
+    if ($preferencesConsent === 'true') {
+      let expires = new Date();
+      expires.setDate(expires.getDate() + 14);
+      cookieJar.setItem(`HT-alert-${id}`, 'dismissed', expires, '/', HT.cookies_domain, true);
+      isVisible = false;
+    }
+    //reset focus to the main element once the banner is removed from the DOM
+    if (document.querySelector('main')) {
+      document.querySelector('main').focus();
+    }
+  }
+
+  if (cookieJar.getItem(`HT-alert-${id}`) === 'dismissed') {
+    isVisible = false;
+  }
+</script>
+
+{#if isVisible}
+  <section class="alert alert-dismissible d-flex mx-3 justify-content-between fade show alert-{type}" id="alert-{id}">
+    <div class="d-flex gap-2">
+      <i
+        class="alert-icon fa-solid"
+        class:fa-circle-xmark={type === 'danger'}
+        class:fa-triangle-exclamation={type === 'warning'}
+        class:fa-bell={type === 'brand'}
+      ></i>
+      {#if type === 'warning'}
+        {#if title}
+          <span class="visually-hidden sr-only">Informational alert</span>
+        {:else}
+          <h2 class="visually-hidden sr-only">Informational alert</h2>
+        {/if}
+      {:else if type === 'danger'}
+        {#if title}
+          <span class="visually-hidden sr-only">Warning alert</span>
+        {:else}
+          <h2 class="visually-hidden sr-only">Warning alert</h2>
+        {/if}
+      {/if}
+      <div class="py-3 {title.length > 0 ? 'd-flex flex-column gap-2' : ''}">
+        {#if title}
+          <h2 class="h3 alert-heading">{title}</h2>
+        {/if}
+        <p class="message">{message}</p>
+        <a class="alert-link" href={link}>{linkText}</a>
+      </div>
+    </div>
+    <div class="close-wrapper">
+      <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" on:click={closeAlert}>
+        <span class="close-icon">
+          <i class="fa-solid fa-xmark icon-default" aria-hidden="true"></i><span class="fa-sr-only">Close banner</span>
+          <i class="fa-solid fa-circle-xmark fa-2x icon-hover" aria-hidden="true"></i><span class="fa-sr-only"
+            >Close banner</span
+          >
+        </span>
+      </button>
+    </div>
+  </section>
+{/if}
+
+<style lang="scss">
+  .alert-warning {
+    --bs-alert-color: var(--color-neutral-800);
+    --bs-alert-border-color: #997404;
+  }
+  .alert-danger {
+    --bs-alert-color: var(--color-neutral-800);
+    --bs-alert-border-color: #b02a37;
+  }
+  .alert-brand {
+    --bs-alert-color: var(--color-neutral-800);
+    --bs-alert-border-color: var(--color-primary-700);
+    --bs-alert-bg: var(--color-primary-100);
+  }
+  .alert {
+    container-type: inline-size;
+    border: none;
+    border-inline-start: 0.25rem solid var(--bs-alert-border-color);
+    padding: 0;
+    border-radius: 0.25rem;
+    box-shadow: 0px 4px 8px 0px rgba(25, 11, 1, 0.04);
+    i.alert-icon {
+      color: var(--bs-alert-border-color);
+      display: flex;
+      width: 1.5rem;
+      padding-block-start: 1rem;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      align-self: stretch;
+      margin-inline-start: 0.5rem;
+      line-height: 1.3125rem;
+    }
+    p,
+    a {
+      line-height: 1.3125rem;
+      letter-spacing: -0.01rem;
+      margin-block-end: 0;
+    }
+    a.alert-link {
+      font-weight: 500;
+      color: var(--bs-alert-color);
+    }
+    .close-wrapper {
+      display: flex;
+      align-items: flex-start;
+    }
+    button {
+      background: var(--bs-alert-bg);
+      border: none;
+      display: flex;
+      width: 2.75rem;
+      height: 2.75rem;
+      padding: 0rem 1rem;
+      justify-content: center;
+      align-items: center;
+      margin-top: 0.25rem;
+    }
+  }
+  @media (min-width: 48em) {
+    /* 768px, bootstrap "medium" and up */
+  }
+
+  @container (min-width: 35rem) {
+    p.message {
+      display: inline;
+    }
+  }
+  @container (width < 35rem) {
+    p.message {
+      margin-block-end: 0.5rem;
+    }
+  }
+  .alert-heading {
+    font-weight: 700;
+    line-height: 1.3125rem; /* 131.25% */
+    letter-spacing: -0.01rem;
+  }
+</style>

--- a/src/js/components/AlertBanner/index.svelte
+++ b/src/js/components/AlertBanner/index.svelte
@@ -1,148 +1,22 @@
 <script>
-  let HT = window.HT || {};
-  let cookieJar = HT.cookieJar;
-  import { preferencesConsent } from '../../lib/store';
+  import BannerMessage from './BannerMessage.svelte';
 
-  export let title = 'Outage: Incomplete search results';
-  // let title = '';
-  export let message = 'Users searching within the full text of all volumes will receive incomplete search results.';
-  export let link = 'https://www.hathitrust.org/press-post/outage-incomplete-search-results/';
-  export let linkText = 'See updates here';
-  export let type = 'warning';
-  //ID should increment with each new alert
-  export let id = 1;
+  let alert;
+  let alertEmpty = true;
 
-  let isVisible = true;
-
-  export function closeAlert() {
-    //if user has functional/preference cookies enabled, set a 14-day cookie to remember dismissed preference
-    if ($preferencesConsent === 'true') {
-      let expires = new Date();
-      expires.setDate(expires.getDate() + 14);
-      cookieJar.setItem(`HT-alert-${id}`, 'dismissed', expires, '/', HT.cookies_domain, true);
-      isVisible = false;
+  const request = async () => {
+    try {
+      const response = await fetch(`/common/firebird/alerts/alert.json`);
+      const data = await response.json();
+      alert = data;
+      alertEmpty = false;
+    } catch (error) {
+      console.log('catch: no alert');
     }
-    //reset focus to the main element once the banner is removed from the DOM
-    if (document.querySelector('main')) {
-      document.querySelector('main').focus();
-    }
-  }
-
-  if (cookieJar.getItem(`HT-alert-${id}`) === 'dismissed') {
-    isVisible = false;
-  }
+  };
+  request();
 </script>
 
-{#if isVisible}
-  <div
-    class="alert alert-dismissible d-flex mx-3 justify-content-between fade show alert-{type}"
-    id="alert-{id}"
-    role="alert"
-  >
-    <div class="d-flex gap-2">
-      <i
-        class="alert-icon fa-solid"
-        class:fa-circle-xmark={type === 'danger'}
-        class:fa-triangle-exclamation={type === 'warning'}
-        class:fa-bell={type === 'brand'}
-      ></i>
-      <div class="py-3 {title.length > 0 ? 'd-flex flex-column gap-2' : ''}">
-        {#if title}
-          <p class="alert-heading">{title}</p>
-        {/if}
-        <p class="message">{message}</p>
-        <a class="alert-link" href={link}>{linkText}</a>
-      </div>
-    </div>
-    <div class="close-wrapper">
-      <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" on:click={closeAlert}>
-        <span class="close-icon">
-          <i class="fa-solid fa-xmark icon-default" aria-hidden="true"></i><span class="fa-sr-only">Close banner</span>
-          <i class="fa-solid fa-circle-xmark fa-2x icon-hover" aria-hidden="true"></i><span class="fa-sr-only"
-            >Close banner</span
-          >
-        </span>
-      </button>
-    </div>
-  </div>
+{#if !alertEmpty}
+  <BannerMessage {...alert}></BannerMessage>
 {/if}
-
-<style lang="scss">
-  .alert-warning {
-    --bs-alert-color: var(--color-neutral-800);
-    --bs-alert-border-color: #997404;
-  }
-  .alert-danger {
-    --bs-alert-color: var(--color-neutral-800);
-    --bs-alert-border-color: #b02a37;
-  }
-  .alert-brand {
-    --bs-alert-color: var(--color-neutral-800);
-    --bs-alert-border-color: var(--color-primary-700);
-    --bs-alert-bg: var(--color-primary-100);
-  }
-  .alert {
-    container-type: inline-size;
-    border: none;
-    border-inline-start: 0.25rem solid var(--bs-alert-border-color);
-    padding: 0;
-    border-radius: 0.25rem;
-    box-shadow: 0px 4px 8px 0px rgba(25, 11, 1, 0.04);
-    i.alert-icon {
-      color: var(--bs-alert-border-color);
-      display: flex;
-      width: 1.5rem;
-      padding-block-start: 1rem;
-      flex-direction: column;
-      align-items: center;
-      gap: 0.5rem;
-      align-self: stretch;
-      margin-inline-start: 0.5rem;
-      line-height: 1.3125rem;
-    }
-    p,
-    a {
-      line-height: 1.3125rem;
-      letter-spacing: -0.01rem;
-      margin-block-end: 0;
-    }
-    a.alert-link {
-      font-weight: 500;
-      color: var(--bs-alert-color);
-    }
-    .close-wrapper {
-      display: flex;
-      align-items: flex-start;
-    }
-    button {
-      background: var(--bs-alert-bg);
-      border: none;
-      display: flex;
-      width: 2.75rem;
-      height: 2.75rem;
-      padding: 0rem 1rem;
-      justify-content: center;
-      align-items: center;
-      margin-top: 0.25rem;
-    }
-  }
-  @media (min-width: 48em) {
-    /* 768px, bootstrap "medium" and up */
-  }
-
-  @container (min-width: 35rem) {
-    p.message {
-      display: inline;
-    }
-  }
-  @container (width < 35rem) {
-    p.message {
-      margin-block-end: 0.5rem;
-    }
-  }
-  .alert-heading {
-    font-weight: 700;
-    line-height: 1.3125rem; /* 131.25% */
-    letter-spacing: -0.01rem;
-  }
-</style>

--- a/src/js/components/AlertBanner/index.svelte
+++ b/src/js/components/AlertBanner/index.svelte
@@ -1,28 +1,25 @@
 <script>
-  import { preferencesConsent } from '../../lib/store';
   let HT = window.HT || {};
   let cookieJar = HT.cookieJar;
+  import { preferencesConsent } from '../../lib/store';
 
-  const alertData = [
-    {
-      title: 'Outage: Incomplete search results',
-      message: 'Users searching within the full text of all volumes will receive incomplete search results.',
-      link: 'https://www.hathitrust.org/press-post/outage-incomplete-search-results/',
-      linkText: 'See updates here',
-      type: 'warning',
-      //ID should increment with each new alert
-      id: 1,
-    },
-  ];
+  export let title = 'Outage: Incomplete search results';
+  // let title = '';
+  export let message = 'Users searching within the full text of all volumes will receive incomplete search results.';
+  export let link = 'https://www.hathitrust.org/press-post/outage-incomplete-search-results/';
+  export let linkText = 'See updates here';
+  export let type = 'warning';
+  //ID should increment with each new alert
+  export let id = 1;
 
   let isVisible = true;
 
-  function closeAlert() {
+  export function closeAlert() {
     //if user has functional/preference cookies enabled, set a 14-day cookie to remember dismissed preference
     if ($preferencesConsent === 'true') {
       let expires = new Date();
       expires.setDate(expires.getDate() + 14);
-      cookieJar.setItem(`HT-alert-${alertData[0].id}`, 'dismissed', expires, '/', HT.cookies_domain, true);
+      cookieJar.setItem(`HT-alert-${id}`, 'dismissed', expires, '/', HT.cookies_domain, true);
       isVisible = false;
     }
     //reset focus to the main element once the banner is removed from the DOM
@@ -31,35 +28,43 @@
     }
   }
 
-  if (cookieJar.getItem(`HT-alert-${alertData[0].id}`) === 'dismissed') {
+  if (cookieJar.getItem(`HT-alert-${id}`) === 'dismissed') {
     isVisible = false;
   }
 </script>
 
 {#if isVisible}
-  {#each alertData as alert}
-    <div class="alert alert-dismissible d-flex mx-3 justify-content-between fade show alert-{alert.type}" role="alert">
-      <div class="d-flex gap-2">
-        <i class="alert-icon fa-solid fa-triangle-exclamation"></i>
-        <div class="d-flex flex-column gap-2 py-3">
-          <p class="alert-heading">{alert.title}</p>
-          <p>{alert.message}</p>
-          <a class="alert-link" href={alert.link}>{alert.linkText}</a>
-        </div>
-      </div>
-      <div class="close-wrapper">
-        <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" on:click={closeAlert}>
-          <span class="close-icon">
-            <i class="fa-solid fa-xmark icon-default" aria-hidden="true"></i><span class="fa-sr-only">Close banner</span
-            >
-            <i class="fa-solid fa-circle-xmark fa-2x icon-hover" aria-hidden="true"></i><span class="fa-sr-only"
-              >Close banner</span
-            >
-          </span>
-        </button>
+  <div
+    class="alert alert-dismissible d-flex mx-3 justify-content-between fade show alert-{type}"
+    id="alert-{id}"
+    role="alert"
+  >
+    <div class="d-flex gap-2">
+      <i
+        class="alert-icon fa-solid"
+        class:fa-circle-xmark={type === 'danger'}
+        class:fa-triangle-exclamation={type === 'warning'}
+        class:fa-bell={type === 'brand'}
+      ></i>
+      <div class="py-3 {title.length > 0 ? 'd-flex flex-column gap-2' : ''}">
+        {#if title}
+          <p class="alert-heading">{title}</p>
+        {/if}
+        <p class="message">{message}</p>
+        <a class="alert-link" href={link}>{linkText}</a>
       </div>
     </div>
-  {/each}
+    <div class="close-wrapper">
+      <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" on:click={closeAlert}>
+        <span class="close-icon">
+          <i class="fa-solid fa-xmark icon-default" aria-hidden="true"></i><span class="fa-sr-only">Close banner</span>
+          <i class="fa-solid fa-circle-xmark fa-2x icon-hover" aria-hidden="true"></i><span class="fa-sr-only"
+            >Close banner</span
+          >
+        </span>
+      </button>
+    </div>
+  </div>
 {/if}
 
 <style lang="scss">
@@ -71,7 +76,13 @@
     --bs-alert-color: var(--color-neutral-800);
     --bs-alert-border-color: #b02a37;
   }
+  .alert-brand {
+    --bs-alert-color: var(--color-neutral-800);
+    --bs-alert-border-color: var(--color-primary-700);
+    --bs-alert-bg: var(--color-primary-100);
+  }
   .alert {
+    container-type: inline-size;
     border: none;
     border-inline-start: 0.25rem solid var(--bs-alert-border-color);
     padding: 0;
@@ -117,6 +128,17 @@
   }
   @media (min-width: 48em) {
     /* 768px, bootstrap "medium" and up */
+  }
+
+  @container (min-width: 35rem) {
+    p.message {
+      display: inline;
+    }
+  }
+  @container (width < 35rem) {
+    p.message {
+      margin-block-end: 0.5rem;
+    }
   }
   .alert-heading {
     font-weight: 700;

--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -28,7 +28,6 @@ body {
 
   hathi-alert-banner {
     grid-area: banner;
-    // display: none;
   }
 
   hathi-website-footer {
@@ -107,10 +106,6 @@ body {
       flex-basis: 43.75rem;
       gap: 2.625rem;
     }
-  }
-
-  .twocol-main > * {
-    // max-width: 43.75rem;
   }
 
   #action-toggle-filters {

--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -28,7 +28,7 @@ body {
 
   hathi-alert-banner {
     grid-area: banner;
-    display: none;
+    // display: none;
   }
 
   hathi-website-footer {


### PR DESCRIPTION
Finishing up DEV-1095 with a few additions to the original outage notifications:
- add [message-only variant](https://656a2bfa011def621f569319-zhhaerpzjb.chromatic.com/iframe.html?args=&globals=viewport:bsLg&id=alert-banner--message-only)
- add ["brand" style variant](https://656a2bfa011def621f569319-zhhaerpzjb.chromatic.com/iframe.html?args=&globals=viewport:bsLg&id=alert-banner--brand)
- hook the alerts up to external json data
- fix accessibility issues
- add stories to [storybook](https://656a2bfa011def621f569319-zhhaerpzjb.chromatic.com/)
- update README with instructions for alert json data

### external data

The biggest hurdle for this update was the external json data. A challenge I ran into was making sure this component could reach the data, whether the component is at www, catalog, or babel. Aaron helped me find the best place and way to reach the data, which will be at `/common/firebird/alerts/alert.json`. This will work across all applications (e.g. https://dev-3.babel.hathitrust.org/common/firebird/alerts/alert.json, but also https://dev-3.catalog.hathitrust.org/common/firebird/alerts/alert.json and https://dev-3.www.hathitrust.org/common/firebird/alerts/alert.json)

### to test

Go to dev-3 and see the test alert! Updating or removing the alert will require manually writing a file to the server, so that part is on me, but the current alert should be visible across all the domains:
- https://dev-3.www.hathitrust.org/
- https://dev-3.catalog.hathitrust.org/Search/Home
- https://dev-3.babel.hathitrust.org/cgi/ls
- https://dev-3.babel.hathitrust.org/cgi/pt?id=1
