### PR TITLE
DEV-1587: fix collection edit modal bugs

### DIFF
--- a/src/js/components/CollectionEditModal/index.svelte
+++ b/src/js/components/CollectionEditModal/index.svelte
@@ -154,7 +154,7 @@
     {/if}
     {#if errorMessage}
       <div role="alert" class="alert alert-block alert-danger mx-3">
-        The form did not submit. Please add a collection name and resubmit the form.
+        The collection could not be saved. Please add a collection name and try again.
       </div>
     {/if}
     <button class="btn btn-secondary" type="button" on:click={() => modal.hide()}>Close</button>

--- a/src/js/components/CollectionEditModal/index.svelte
+++ b/src/js/components/CollectionEditModal/index.svelte
@@ -2,6 +2,8 @@
   import Modal from '../Modal';
 
   let modal;
+  let errorMessage,
+    nameError = false;
 
   export let c = '__NEW__';
   export let cn = '';
@@ -25,17 +27,28 @@
   }
 
   function saveChanges(event) {
-    let params = new URLSearchParams();
-    if (c != '__NEW__') {
-      params.set('c', c);
-    }
-    params.set('cn', cn.trim());
-    params.set('desc', desc.trim());
-    params.set('contributor_name', contributorName.trim());
-    params.set('shrd', shared);
+    const formValid = document.querySelector('form#edit-collection.needs-validation');
+    //check for required field
+    if (!formValid.checkValidity()) {
+      // event.stopPropogation();
+      formValid.classList.add('was-validated');
+      if (formValid.querySelector('#cn.form-control:invalid')) {
+        nameError = true;
+        errorMessage = true;
+      }
+    } else {
+      let params = new URLSearchParams();
+      if (c != '__NEW__') {
+        params.set('c', c);
+      }
+      params.set('cn', cn.trim());
+      params.set('desc', desc.trim());
+      params.set('contributor_name', contributorName.trim());
+      params.set('shrd', shared);
 
-    submitAction(params);
-    modal.hide();
+      submitAction(params);
+      modal.hide();
+    }
   }
 
   $: if (cn.length == 100) {
@@ -54,9 +67,11 @@
 <Modal bind:this={modal} scrollable={true}>
   <svelte:fragment slot="title">{c == '__NEW__' ? 'New' : 'Edit'} Collection</svelte:fragment>
   <svelte:fragment slot="body">
-    <form>
+    <form id="edit-collection" class="needs-validation">
       <div class="mb-3">
-        <label for="cn" class="form-label">Collection Name</label>
+        <label for="cn" class="form-label"
+          >Collection Name <span class="required" aria-hidden="true">(required)</span>
+        </label>
         <input
           type="text"
           class="form-control"
@@ -65,9 +80,15 @@
           aria-describedby="cn-help"
           maxlength="100"
           bind:value={cn}
+          required
         />
         <div id="cn-help" class="form-text">
           Collection names can be 100 characters long ({100 - cn.length} characters remaining).
+        </div>
+        <div class="invalid-feedback" id="name-error">
+          {#if nameError}
+            <span>Error: Please provide a collection name.</span>
+          {/if}
         </div>
       </div>
       <div class="mb-3">
@@ -135,6 +156,11 @@
         <p class="mb-0">
           <strong>This collection will be temporary.</strong> Log in to create permanent and public collections.
         </p>
+      </div>
+    {/if}
+    {#if errorMessage}
+      <div role="alert" class="alert alert-block alert-danger mx-3">
+        The form did not submit. Please add a collection name and resubmit the form.
       </div>
     {/if}
     <button class="btn btn-secondary" type="button" on:click={() => modal.hide()}>Close</button>

--- a/src/js/components/CollectionEditModal/index.svelte
+++ b/src/js/components/CollectionEditModal/index.svelte
@@ -10,6 +10,10 @@
   export let shared = 0;
   export let userIsAnonymous = true;
 
+  if (HT.login_status.logged_in) {
+    userIsAnonymous = false;
+  }
+
   export let submitAction = function () {};
 
   export function show() {
@@ -43,6 +47,8 @@
   $: if (contributorName.length == 255) {
     HT.live.announce('Contributor Name has a maximum size of 255');
   }
+
+  $: console.log('user anonymous?', userIsAnonymous);
 </script>
 
 <Modal bind:this={modal} scrollable={true}>

--- a/src/js/components/CollectionEditModal/index.svelte
+++ b/src/js/components/CollectionEditModal/index.svelte
@@ -30,7 +30,6 @@
     const formValid = document.querySelector('form#edit-collection.needs-validation');
     //check for required field
     if (!formValid.checkValidity()) {
-      // event.stopPropogation();
       formValid.classList.add('was-validated');
       if (formValid.querySelector('#cn.form-control:invalid')) {
         nameError = true;
@@ -60,14 +59,12 @@
   $: if (contributorName.length == 255) {
     HT.live.announce('Contributor Name has a maximum size of 255');
   }
-
-  $: console.log('user anonymous?', userIsAnonymous);
 </script>
 
 <Modal bind:this={modal} scrollable={true}>
   <svelte:fragment slot="title">{c == '__NEW__' ? 'New' : 'Edit'} Collection</svelte:fragment>
   <svelte:fragment slot="body">
-    <form id="edit-collection" class="needs-validation">
+    <form id="edit-collection" class="needs-validation" novalidate>
       <div class="mb-3">
         <label for="cn" class="form-label"
           >Collection Name <span class="required" aria-hidden="true">(required)</span>
@@ -82,13 +79,10 @@
           bind:value={cn}
           required
         />
-        <div id="cn-help" class="form-text">
-          Collection names can be 100 characters long ({100 - cn.length} characters remaining).
-        </div>
-        <div class="invalid-feedback" id="name-error">
+        <div id="cn-help" class="form-text" class:text-danger={nameError}>
           {#if nameError}
             <span>Error: Please provide a collection name.</span>
-          {/if}
+          {/if} Collection names can be 100 characters long ({100 - cn.length} characters remaining).
         </div>
       </div>
       <div class="mb-3">

--- a/src/js/components/CollectionsToolbar/index.svelte
+++ b/src/js/components/CollectionsToolbar/index.svelte
@@ -4,12 +4,7 @@
   import CollectionEditModal from '../CollectionEditModal';
 
   export let editable = false;
-  export let userIsAnonymous = true;
-  export let colldata = null;
   export let collid = null;
-  // export let collname = null;
-  // export let desc = null;
-  // export let shared = 0;
 
   let userCollections = [];
   let div;
@@ -344,7 +339,7 @@
   </div>
 {/if}
 
-<CollectionEditModal bind:this={modal} {userIsAnonymous} {c} {cn} {desc} {contributorName} {shared} {submitAction} />
+<CollectionEditModal bind:this={modal} {c} {cn} {desc} {contributorName} {shared} {submitAction} />
 
 <style>
 </style>


### PR DESCRIPTION
## 'new collection' modal trigger user always anonymous

### current behavior

From `mb` [landing page](https://babel.hathitrust.org/cgi/mb?colltype=featured), when a user clicks "New Collection" (from the collection toolbar under "Featured collections" and above the listing of collections), the New Collection (also sometimes says Edit Collection, depending on the situation) modal appears. Regardless of login status, this modal tells the user their new collection will be temporary unless they log in (even if the user is already logged in).

### the fix

The modal already had a `userIsAnonymous` variable but it wasn't getting set in this context (via the _results_ toolbar in `mb`) so the change in UI never happened. (To be fair, this variable  _is_ getting set when you create a collection via `ls` _collection_ toolbar). Instead of relying on passing down the variable from the `ls` or `mb` XML, I'm using the `HT` global variable that holds info about login status: `HT.login_status.logged_in`. 

### to test

On [dev-3](https://dev-3.babel.hathitrust.org/cgi/mb), click the "New Collection" button before logging in and see the usual "This collection will be temporary" message. Log in, then click the button again. The message should not appear and you should have the ability to make the collection public.

## modal allows form submit without collection name (which leads to Application Error)

### current behavior

If you create a new collection but don't give it a name in the form, you can still submit the form (via "Save Changes" button). After the form is submitted, the application can't redirect you to your collection or list of collections because you didn't supply any information, so you'll get an "Application Error" page instead.

### the fix

I added form validation to the "Collection name" field in the New Collection form. 

### to test

On [dev-3](https://dev-3.babel.hathitrust.org/cgi/mb), click the "New Collection" button and without filling out any fields, click "Save Changes" to submit the form. You should now get two error messages: one under the Collection Name field and another in the footer of the modal letting you know that you need to fix something and try again.