### PR TITLE
add 'apahce-test' as localhost prefix for domains

### DIFF
--- a/src/js/lib/utils.js
+++ b/src/js/lib/utils.js
@@ -34,7 +34,7 @@ function setDomains() {
   if (HT.is_dev) {
     var prefix = hostname.split('.')[0];
     console.log('-- main setting hostname', prefix, hostname);
-    if (prefix == 'localhost') {
+    if (prefix == 'localhost' || prefix == 'apache-test') {
       if (location.port) {
         hostname += ':' + location.port;
       }


### PR DESCRIPTION
This is a fix for playwright testing and only affects development environments, and specifically development environments with a hostname of `apache-host` (which should only be playwright tests). 