### PR TITLE
ETT-324: update account dropdown UI

### DIFF
--- a/src/js/components/Navbar/Navbar.stories.js
+++ b/src/js/components/Navbar/Navbar.stories.js
@@ -76,7 +76,7 @@ export const DesktopLoggedInResourceSharingRole = {
   ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const accountButton = canvas.getByRole('button', { name: 'My account' });
+    const accountButton = canvas.getByLabelText('My account');
     await userEvent.click(accountButton);
   },
 };
@@ -94,7 +94,7 @@ export const DesktopLoggedInResourceSharingRoleActivated = {
   ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const accountButton = canvas.getByRole('button', { name: 'My account' });
+    const accountButton = canvas.getByLabelText('My account');
     await userEvent.click(accountButton);
   },
 };
@@ -132,7 +132,7 @@ export const MobileOpenMenu = {
   parameters: { ...Mobile.parameters },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const mobileMenuButton = await canvas.getByLabelText('Toggle navigation');
+    const mobileMenuButton = canvas.getByLabelText('Toggle navigation');
     await userEvent.click(mobileMenuButton);
   },
 };
@@ -141,8 +141,8 @@ export const MobileDropdownMenuSelected = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const mobileMenuButton = await canvas.getByLabelText('Toggle navigation');
-    const mainMenu = await canvas.getByText(/member libraries/i);
+    const mobileMenuButton = canvas.getByLabelText('Toggle navigation');
+    const mainMenu = canvas.getByText(/member libraries/i);
 
     await userEvent.click(mobileMenuButton);
     await userEvent.click(mainMenu);
@@ -159,6 +159,45 @@ export const MobileLoggedIn = {
       props: { loggedIn: true },
     }),
   ],
+};
+export const MobileLoggedInResourceSharingRole = {
+  parameters: { ...Mobile.parameters },
+  args: {
+    loggedIn: true,
+  },
+  decorators: [
+    () => ({
+      Component: PingCallbackDecorator,
+      props: { loggedIn: true, role: 'resourceSharing', hasActivatedRole: false },
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const mobileMenuButton = canvas.getByLabelText('Toggle navigation');
+    const accountButton = canvas.getByLabelText('My account');
+    await userEvent.click(mobileMenuButton);
+    await userEvent.click(accountButton);
+  },
+};
+export const MobileLoggedInResourceSharingRoleActivated = {
+  parameters: { ...Mobile.parameters },
+  args: {
+    loggedIn: true,
+    hasActivatedRole: true,
+  },
+  decorators: [
+    () => ({
+      Component: PingCallbackDecorator,
+      props: { loggedIn: true, role: 'resourceSharing', hasActivatedRole: true },
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const mobileMenuButton = canvas.getByLabelText('Toggle navigation');
+    const accountButton = canvas.getByLabelText('My account' );
+    await userEvent.click(mobileMenuButton);
+    await userEvent.click(accountButton);
+  },
 };
 export const MobileLoggedInWithNotifications = {
   parameters: { ...Mobile.parameters },
@@ -197,10 +236,37 @@ export const MobileLoggedInMyAccountDropdown = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const mobileMenuButton = await canvas.getByLabelText('Toggle navigation');
-    const myAccount = await canvas.getByText(/my account/i);
+    const mobileMenuButton =  canvas.getByLabelText('Toggle navigation');
+    const myAccount =  canvas.getByLabelText('My account');
 
     await userEvent.click(mobileMenuButton);
     await userEvent.click(myAccount);
+  },
+};
+export const MobileLoggedInResourceSharingRoleActivatedHasNotification = {
+  parameters: { ...Mobile.parameters },
+  args: {
+    loggedIn: true,
+    hasActivatedRole: true,
+  },
+  decorators: [
+    () => ({
+      Component: PingCallbackDecorator,
+      props: { loggedIn: true, role: 'resourceSharing', hasActivatedRole: true, notificationData: [
+        {
+          title: 'A navbar story',
+          message: 'Once upon a time there was a user with notifications',
+          read_more_label: 'Do you want to know more?',
+          read_more_link: 'https://umich.edu',
+        },
+      ], },
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const mobileMenuButton = canvas.getByLabelText('Toggle navigation');
+    const accountButton = canvas.getByLabelText('My account' );
+    await userEvent.click(mobileMenuButton);
+    await userEvent.click(accountButton);
   },
 };

--- a/src/js/components/Navbar/Navbar.stories.js
+++ b/src/js/components/Navbar/Navbar.stories.js
@@ -63,20 +63,40 @@ export const DesktopLoggedIn = {
     }),
   ],
 };
-export const DesktopLoggedInAccountDropdown = {
+export const DesktopLoggedInResourceSharingRole = {
   parameters: { ...Default.parameters },
   args: {
-    loggedIn: false,
-    hasSwitchableRole: true,
-    hasActivatedRole: false,
-    role: 'resourceSharing'
+    loggedIn: true,
   },
   decorators: [
     () => ({
       Component: PingCallbackDecorator,
-      props: { loggedIn: true },
+      props: { loggedIn: true, role: 'resourceSharing', hasActivatedRole: false },
     }),
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const accountButton = canvas.getByRole('button', { name: 'My account' });
+    await userEvent.click(accountButton);
+  },
+};
+export const DesktopLoggedInResourceSharingRoleActivated = {
+  parameters: { ...Default.parameters },
+  args: {
+    loggedIn: true,
+    hasActivatedRole: true,
+  },
+  decorators: [
+    () => ({
+      Component: PingCallbackDecorator,
+      props: { loggedIn: true, role: 'resourceSharing', hasActivatedRole: true },
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const accountButton = canvas.getByRole('button', { name: 'My account' });
+    await userEvent.click(accountButton);
+  },
 };
 export const DesktopLoggedInWithNotifications = {
   parameters: { ...Default.parameters },

--- a/src/js/components/Navbar/Navbar.stories.js
+++ b/src/js/components/Navbar/Navbar.stories.js
@@ -43,30 +43,33 @@ export const DesktopLoginModalOpen = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const loginButton = await canvas.getByTestId('login-button');
+    const loginButton = canvas.getByTestId('login-button');
     // const loginButton = await canvas.getByRole('button', { name: /log in/i });
     // const loginButton = await canvas.locator('#navbarNavDropdown:has-text"Log In"');
     await userEvent.click(loginButton);
   },
 };
-// export const DesktopShortViewportModal = {
-//   parameters: {
-//     viewport: {
-//       defaultViewport: 'shortDesktop'
-//     }
-//   },
-// play: async ({ canvasElement }) => {
-//   const canvas = within(canvasElement);
 
-//   const loginButton = await canvas.getByRole('button', {name: /log in/i});
-//   await userEvent.click(loginButton);
-// },
-// }
 export const DesktopLoggedIn = {
   parameters: { ...Default.parameters },
   args: {
     loggedIn: false,
     isOpen: true,
+  },
+  decorators: [
+    () => ({
+      Component: PingCallbackDecorator,
+      props: { loggedIn: true },
+    }),
+  ],
+};
+export const DesktopLoggedInAccountDropdown = {
+  parameters: { ...Default.parameters },
+  args: {
+    loggedIn: false,
+    hasSwitchableRole: true,
+    hasActivatedRole: false,
+    role: 'resourceSharing'
   },
   decorators: [
     () => ({

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -328,37 +328,38 @@
             data-bs-toggle="dropdown"
             ><span>Get Help</span>
           </a>
-          <ul class="dropdown-menu dropdown-menu-end">
-            <div class="d-flex flex-column gap-4">
-              <li class="px-3">
+          <ul class="dropdown-menu dropdown-menu-end p-0">
+            <div class="d-flex flex-column gap-2">
+              <li class="p-2">
                 <a
                   href="https://hathitrust.atlassian.net/servicedesk/customer/portals"
-                  class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
+                  class="dropdown-item px-0 d-flex flex-row align-items-center gap-2"
                 >
-                  <span>Find Help</span>
-                  <i class="fa-solid fa-square-arrow-up-right fa-fw" />
+                  <i class="fa-solid fa-square-arrow-up-right fa-fw text-neutral-500" aria-hidden="true" /><span
+                    >Find Help</span
+                  >
                 </a>
               </li>
-              <li class="px-3">
+              <li class="p-2">
                 <a
                   href="#"
                   id="ask-a-question"
-                  class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
+                  class="dropdown-item px-0 d-flex flex-row align-items-center gap-2"
                   on:click|preventDefault={() => openFeedback('questions')}
                 >
-                  <span>Ask a Question</span>
-                  <i class="fa-regular fa-circle-question" />
+                  <i class="fa-solid fa-circle-question fa-fw text-neutral-500" aria-hidden="true" /><span
+                    >Ask a Question</span
+                  >
                 </a>
               </li>
-              <li class="px-3">
+              <li class="p-2">
                 <a
                   href="#"
                   id="report-a-problem"
-                  class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
+                  class="dropdown-item px-0 d-flex flex-row align-items-center gap-2"
                   on:click|preventDefault={() => openFeedback(location)}
                 >
-                  <span>Report a Problem</span>
-                  <i class="fa-solid fa-bug" />
+                  <i class="fa-solid fa-bug fa-fw text-neutral-500" aria-hidden="true" /><span>Report a Problem</span>
                 </a>
               </li>
             </div>
@@ -368,11 +369,12 @@
           {#if loggedIn}
             <li id="my-account" class="nav-item dropdown">
               <a
-                class="nav-link dropdown-toggle text-uppercase d-flex flex-row justify-content-between align-items-center text-black-hover text-black-focus"
+                class="nav-link dropdown-toggle d-flex flex-row justify-content-between align-items-center text-black-hover text-black-focus"
                 href="#"
                 role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
+                aria-label="My account"
               >
                 <div class="d-flex justify-content-center align-items-center">
                   <span
@@ -380,12 +382,14 @@
                     class="account-icon me-n1 d-flex align-items-center justify-content-center border border-neutral-300 rounded-circle bg-neutral-100"
                   >
                     {#if hasActivatedRole}
-                      <i class="fa-solid fa-user-plus text-primary-600" aria-label="My account" />
+                      <i class="fa-solid fa-user-plus text-primary-600" />
                     {:else}
-                      <i class="fa-solid fa-user text-neutral-800" aria-label="My account" />
+                      <i class="fa-solid fa-user text-neutral-800" />
                     {/if}
                   </span>
-                  <span class="account-text ms-3" aria-hidden="true">My Account</span>
+                  <span class="ms-3 d-xl-none">My Account</span><span class="visually-hidden d-none d-xl-block"
+                    >My Account</span
+                  >
                 </div>
               </a>
               <ul class="dropdown-menu dropdown-menu-end p-0" class:accountDropdown={!hasSwitchableRoles}>
@@ -448,12 +452,8 @@
                             window.location.href
                           )}`}"
                           role="button"
-                          ><span class="needs-hover-state">
-                            {#if hasActivatedRole}
-                              Switch to Member role
-                            {:else}
-                              Switch to {role} role
-                            {/if}
+                          ><i class="fa-solid fa-user-group fa-fw" aria-hidden="true" /><span class="needs-hover-state">
+                            Switch Role
                           </span></a
                         >
                       </li>
@@ -462,7 +462,10 @@
                       <a
                         class="dropdown-item px-0 d-flex flex-row gap-2 align-items-center"
                         href="//{`${HT.service_domain}/cgi/logout?${encodeURIComponent(window.location.href)}`}"
-                        role="button"><span class="needs-hover-state">Sign Out</span></a
+                        role="button"
+                        ><i class="fa-solid fa-arrow-right-from-bracket fa-fw" aria-hidden="true" /><span
+                          class="needs-hover-state">Sign Out</span
+                        ></a
                       >
                     </li>
                   </div>
@@ -473,11 +476,12 @@
             <LoginFormModal bind:this={modal} />
             <li class="nav-item">
               <a
-                class="nav-link text-uppercase d-flex flex-row justify-content-between align-items-center"
+                id="log-in"
+                class="nav-link text-uppercase d-flex align-items-center gap-2"
                 href="#"
                 role="button"
                 data-testid="login-button"
-                on:click|preventDefault={openLogin}>Sign In<i class="fa-solid fa-user fa-fw" /></a
+                on:click|preventDefault={openLogin}><i class="fa-solid fa-user fa-fw" aria-hidden="true" /> Log In</a
               >
             </li>
           {/if}
@@ -558,10 +562,26 @@
         background: white;
         border-top: none;
       }
+      #log-in {
+        flex-direction: row;
+        @media (min-width: 1200px) {
+          flex-direction: row-reverse;
+        }
+      }
+
       a {
         @media (min-width: 1200px) {
           gap: 0.75rem;
         }
+      }
+      ul.dropdown-menu {
+        background: var(--color-shades-0);
+      }
+    }
+    .nav-item:nth-of-type(2) ul.dropdown-menu div {
+      padding: 0.5rem;
+      @media (min-width: 1200px) {
+        padding: 1rem 0.5rem;
       }
     }
     .nav-item:last-of-type {
@@ -665,7 +685,7 @@
   }
   @media (min-width: 1200px) {
     #my-account .dropdown-menu {
-      width: 16rem;
+      width: 14rem;
     }
     #my-account ul.accountDropdown {
       width: 11rem;
@@ -686,7 +706,6 @@
     --bs-dropdown-link-hover-bg: var(--color-neutral-50);
 
     div {
-      padding-top: 0.5rem;
       @media (min-width: 1200px) {
         padding-top: 0;
       }
@@ -715,6 +734,10 @@
       --bs-dropdown-box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.1);
       --bs-dropdown-link-hover-bg: #fff;
       margin-top: 1rem;
+
+      a.dropdown-item {
+        display: inline;
+      }
     }
     &.dropdown-menu-end {
       padding-top: 0;

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -380,15 +380,15 @@
                     class="account-icon me-n1 d-flex align-items-center justify-content-center border border-neutral-300 rounded-circle bg-neutral-100"
                   >
                     {#if hasActivatedRole}
-                      <i class="fa-solid fa-user-plus text-primary-600" aria-hidden="true" />
+                      <i class="fa-solid fa-user-plus text-primary-600" aria-label="My account" />
                     {:else}
-                      <i class="fa-solid fa-user text-neutral-800" aria-hidden="true" />
+                      <i class="fa-solid fa-user text-neutral-800" aria-label="My account" />
                     {/if}
                   </span>
-                  <span class="account-text ms-3">My Account</span>
+                  <span class="account-text ms-3" aria-hidden="true">My Account</span>
                 </div>
               </a>
-              <ul class="dropdown-menu dropdown-menu-end p-0">
+              <ul class="dropdown-menu dropdown-menu-end p-0" class:accountDropdown={!hasSwitchableRoles}>
                 <div class="d-flex flex-column">
                   {#if hasSwitchableRoles}
                     <li class="d-flex p-3 current-role align-items-center">
@@ -443,7 +443,7 @@
                     {#if hasSwitchableRoles}
                       <li class="">
                         <a
-                          class="dropdown-item px-0 d-flex flex-row gap-2 align-items-center"
+                          class="dropdown-item px-0 d-flex flex-row gap-2 align-items-center switch-roles"
                           href="//{`${HT.service_domain}/cgi/ping/switch?target=${encodeURIComponent(
                             window.location.href
                           )}`}"
@@ -626,7 +626,10 @@
       display: none;
     }
   }
-
+  #my-account a.switch-roles {
+    max-width: 13rem;
+    white-space: pre-wrap;
+  }
   .hasNotification {
     position: relative;
     &::after {
@@ -664,6 +667,9 @@
     #my-account .dropdown-menu {
       width: 16rem;
     }
+    #my-account ul.accountDropdown {
+      width: 11rem;
+    }
   }
   .dropdown-menu {
     --bs-dropdown-padding-y: 1rem;
@@ -686,6 +692,8 @@
       }
     }
     a {
+      line-height: 1.125rem;
+      letter-spacing: -0.00875rem;
       &:hover {
         text-decoration: underline;
       }

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -26,10 +26,10 @@
   export let compact = false;
   export let userNavigation = true;
 
-  const switchableRoles = ['enhancedTextProxy', 'totalAccess','resourceSharing'];
+  const switchableRoles = ['enhancedTextProxy', 'totalAccess', 'resourceSharing'];
   const switchableRolesLabels = {};
-  switchableRolesLabels['enhancedTextProxy'] = 'ATRS';
-  switchableRolesLabels['totalAccess'] = 'CAA';
+  switchableRolesLabels['enhancedTextProxy'] = 'Accessible Text Request Service';
+  switchableRolesLabels['totalAccess'] = 'Collection Administrative Access';
   switchableRolesLabels['resourceSharing'] = 'Resource Sharing';
 
   function toggleSearch() {
@@ -368,7 +368,7 @@
           {#if loggedIn}
             <li id="my-account" class="nav-item dropdown">
               <a
-                class="nav-link dropdown-toggle text-uppercase d-flex flex-row justify-content-between align-items-center"
+                class="nav-link dropdown-toggle text-uppercase d-flex flex-row justify-content-between align-items-center text-black-hover text-black-focus"
                 href="#"
                 role="button"
                 data-bs-toggle="dropdown"
@@ -380,72 +380,92 @@
                     class="account-icon me-n1 d-flex align-items-center justify-content-center border border-neutral-300 rounded-circle bg-neutral-100"
                   >
                     {#if hasActivatedRole}
-                      <i class="fa-solid fa-bolt-lightning text-primary-600" />
+                      <i class="fa-solid fa-user-plus text-primary-600" aria-hidden="true" />
                     {:else}
-                      <i class="fa-solid fa-user text-neutral-800" />
+                      <i class="fa-solid fa-user text-neutral-800" aria-hidden="true" />
                     {/if}
                   </span>
                   <span class="account-text ms-3">My Account</span>
                 </div>
               </a>
-              <ul class="dropdown-menu dropdown-menu-end">
-                <div class="d-flex flex-column gap-4">
-                  <li class="px-3">
-                    <button
-                      class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                      data-disabled={!hasNotification}
-                      disabled={!hasNotification ? true : null}
-                      on:click={notificationsModal.show()}
-                      ><span class="needs-hover-state"
-                        >Notifications {#if hasNotification}({notificationsManager.count()}){/if}</span
-                      >
-                      <i class="fa-solid fa-bell fa-fw" class:opacity-25={!hasNotification} />
-                    </button>
-                  </li>
+              <ul class="dropdown-menu dropdown-menu-end p-0">
+                <div class="d-flex flex-column">
                   {#if hasSwitchableRoles}
-                    <li style="margin-bottom: -1rem">
-                      <h6 class="dropdown-header">
-                        Current Role: {hasActivatedRole ? role : 'Member'}
-                      </h6>
-                    </li>
-                    <li class="px-3">
-                      <a
-                        class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                        href="//{`${HT.service_domain}/cgi/ping/switch?target=${encodeURIComponent(
-                          window.location.href
-                        )}`}"
-                        role="button"
-                        ><span class="needs-hover-state">
-                          {#if hasActivatedRole}
-                            Switch Role: Member
-                          {:else}
-                            Switch Role: {role}
-                          {/if}
-                        </span><i class="fa-solid fa-bolt-lightning fa-fw" /></a
+                    <li class="d-flex p-3 current-role align-items-center">
+                      <span
+                        class="account-icon d-flex align-items-center justify-content-center border border-neutral-300 rounded-circle bg-neutral-100"
                       >
+                        {#if hasActivatedRole}
+                          <i class="fa-solid fa-user-plus text-primary-600" aria-hidden="true" />
+                        {:else}
+                          <i class="fa-solid fa-user text-neutral-800" aria-hidden="true" />
+                        {/if}
+                      </span>
+                      <div class="d-flex flex-column align-items-start gap-1">
+                        <span class="role-heading"> Current Role </span>
+                        <span class="role-active">{hasActivatedRole ? role : 'Member'}</span>
+                      </div>
+                    </li>
+
+                    <li aria-hidden="true">
+                      <hr class="dropdown-divider" />
                     </li>
                   {/if}
-                  <li class="px-3">
-                    <a
-                      class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                      href="//{`${HT.service_domain}/cgi/mb?a=listcs&colltype=my-collections`}"
-                      role="button"
-                      ><span class="needs-hover-state">My Collections</span><i class="fa-solid fa-list fa-fw" /></a
-                    >
-                  </li>
-                  <li style="margin-top: -1rem; margin-bottom: -1rem;">
+                  <div class="d-flex flex-column gap-3 p-3">
+                    <li class="">
+                      <button
+                        class="dropdown-item px-0 d-flex flex-row gap-2 align-items-center"
+                        data-disabled={!hasNotification}
+                        disabled={!hasNotification ? true : null}
+                        on:click={notificationsModal.show()}
+                        ><i class="fa-solid fa-bell fa-fw" class:opacity-25={!hasNotification} /><span
+                          class="needs-hover-state"
+                          aria-hidden="true"
+                          >Notifications {#if hasNotification}({notificationsManager.count()}){/if}</span
+                        >
+                      </button>
+                    </li>
+                    <li class="">
+                      <a
+                        class="dropdown-item px-0 d-flex flex-row gap-2 align-items-center"
+                        href="//{`${HT.service_domain}/cgi/mb?a=listcs&colltype=my-collections`}"
+                        role="button"
+                        ><i class="fa-solid fa-list fa-fw" aria-hidden="true" /><span class="needs-hover-state"
+                          >My Collections</span
+                        ></a
+                      >
+                    </li>
+                  </div>
+                  <li aria-hidden="true">
                     <hr class="dropdown-divider" />
                   </li>
-                  <li class="px-3">
-                    <a
-                      class="dropdown-item px-0 d-flex flex-row justify-content-between align-items-center"
-                      href="//{`${HT.service_domain}/cgi/logout?${encodeURIComponent(window.location.href)}`}"
-                      role="button"
-                      ><span class="needs-hover-state">Log Out</span><i
-                        class="fa-solid fa-arrow-right-from-bracket fa-fw"
-                      /></a
-                    >
-                  </li>
+                  <div class="p-3 d-flex flex-column gap-3">
+                    {#if hasSwitchableRoles}
+                      <li class="">
+                        <a
+                          class="dropdown-item px-0 d-flex flex-row gap-2 align-items-center"
+                          href="//{`${HT.service_domain}/cgi/ping/switch?target=${encodeURIComponent(
+                            window.location.href
+                          )}`}"
+                          role="button"
+                          ><span class="needs-hover-state">
+                            {#if hasActivatedRole}
+                              Switch to Member role
+                            {:else}
+                              Switch to {role} role
+                            {/if}
+                          </span></a
+                        >
+                      </li>
+                    {/if}
+                    <li class="">
+                      <a
+                        class="dropdown-item px-0 d-flex flex-row gap-2 align-items-center"
+                        href="//{`${HT.service_domain}/cgi/logout?${encodeURIComponent(window.location.href)}`}"
+                        role="button"><span class="needs-hover-state">Sign Out</span></a
+                      >
+                    </li>
+                  </div>
                 </div>
               </ul>
             </li>
@@ -457,7 +477,7 @@
                 href="#"
                 role="button"
                 data-testid="login-button"
-                on:click|preventDefault={openLogin}>Log In<i class="fa-solid fa-user fa-fw" /></a
+                on:click|preventDefault={openLogin}>Sign In<i class="fa-solid fa-user fa-fw" /></a
               >
             </li>
           {/if}
@@ -564,6 +584,9 @@
     i {
       color: var(--color-primary-600);
     }
+    #my-account ul.dropdown-menu li:not(.current-role) i {
+      color: var(--color-neutral-500);
+    }
     .needs-hover-state:hover {
       text-decoration: underline;
     }
@@ -574,9 +597,29 @@
       color: var(--color-primary-600);
     }
   }
-  #my-account a span.account-icon {
-    width: 40px;
-    height: 40px;
+  .current-role {
+    gap: 0.75rem;
+  }
+  .role-heading {
+    font-size: 0.75rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 1.125rem;
+    letter-spacing: -0.0075rem;
+  }
+  .role-active {
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 1.3125rem;
+    letter-spacing: -0.01rem;
+  }
+  .account-icon {
+    min-width: 2.5rem;
+    height: 2.5rem;
+  }
+  #my-account a.nav-link div {
+    text-decoration: none;
   }
   #my-account .account-text {
     @media (min-width: 1200px) {
@@ -613,6 +656,15 @@
   .dropdown-toggle::after {
     font-size: 1.1em;
   }
+
+  .dropdown-divider {
+    margin: 0;
+  }
+  @media (min-width: 1200px) {
+    #my-account .dropdown-menu {
+      width: 16rem;
+    }
+  }
   .dropdown-menu {
     --bs-dropdown-padding-y: 1rem;
     --bs-dropdown-font-size: var(--ht-text-sm);
@@ -638,6 +690,13 @@
         text-decoration: underline;
       }
     }
+    a.dropdown-item span {
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
     @media (min-width: 1200px) {
       --bs-dropdown-padding-y: 1.5rem;
       --bs-dropdown-item-padding-y: 0;

--- a/src/js/decorators/PingCallbackDecorator.svelte
+++ b/src/js/decorators/PingCallbackDecorator.svelte
@@ -11,6 +11,8 @@
   export let prefs = null;
   export let notificationData = null;
   export let cookieData = null;
+  export let role;
+  export let hasActivatedRole;
 
   const HT = {};
   HT.get_pong_target = function (href) {
@@ -31,6 +33,7 @@
   HT.login_status = {
     logged_in: loggedIn,
     idp_list: [],
+    r: null,
   };
 
   HT.login_status.notificationData = notificationData || [];
@@ -42,6 +45,14 @@
       { name: 'Central Moosylvania University', sdrinst: 'central', idp_url: fakeIdpUrl('central') },
       { name: 'Eastern Moosylvania University', sdrinst: 'eastern', idp_url: fakeIdpUrl('eastern') },
     ];
+  } else if (loggedIn && role) {
+    HT.login_status.institutionName = 'Moosylvania State';
+    HT.login_status.institutionCode = 'state';
+    HT.login_status.r = { [role]: hasActivatedRole };
+    if (!prefs) {
+      prefs = {};
+    }
+    prefs.sdrinst = 'state';
   } else {
     HT.login_status.institutionName = 'Moosylvania State';
     HT.login_status.institutionCode = 'state';
@@ -55,7 +66,8 @@
   HT.loginStatus = writable(HT.login_status);
   globalThis.HT = HT;
 
-  $: console.log('LoginStatusDecorator', loggedIn, prefs, notificationData);
+  $: console.log('LoginStatusDecorator', loggedIn, prefs, notificationData, role);
+  $: console.log('HT.login_status.r', HT.login_status.r);
 </script>
 
 <slot />

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -154,6 +154,7 @@ $utilities: map-merge(
     'color': (
       property: color,
       class: text,
+      state: hover focus,
       local-vars: (
         'text-opacity': 1,
       ),
@@ -163,6 +164,7 @@ $utilities: map-merge(
           (
             'neutral-100': $ht-color-neutral-100,
             'neutral-200': $ht-color-neutral-200,
+            'neutral-500': $ht-color-neutral-500,
             'neutral-800': $ht-color-neutral-800,
             'neutral-900': $ht-color-neutral-900,
             'cyan-700': $cyan-700,
@@ -205,6 +207,7 @@ $utilities: map-merge(
             'neutral-50': $ht-color-neutral-50,
             'neutral-100': $ht-color-neutral-100,
             'neutral-200': $ht-color-neutral-200,
+            'neutral-500': $ht-color-neutral-500,
             'transparent': transparent,
             'body-secondary':
               rgba(
@@ -236,6 +239,7 @@ $utilities: map-merge(
           (
             'neutral-200': $ht-color-neutral-200,
             'neutral-300': $ht-color-neutral-300,
+            'neutral-500': $ht-color-neutral-500,
           )
         ),
     ),


### PR DESCRIPTION
It looks like a lot changed here, but I mostly re-arranged markup that already existed and changed a little bit of CSS/bootstrap utilities. I also added new stories! See the Chromatic build below for more on those. 

I staged this on dev-3, but without an active role, it will be hard to see it. You _could_ pull this branch down and use the `switch_auth` babel utility to see this in action, but it's probably easier to use storybook/chromatic. 