### PR TITLE
ETT-429: a11y fixes for resource sharing UI

### DIFF
--- a/src/js/components/Modal/index.svelte
+++ b/src/js/components/Modal/index.svelte
@@ -13,13 +13,14 @@
   export let modalLarge = false;
   export let fullscreenOnMobile = false;
   export let focusHelpOnClose = false;
+  export let focusMyAccountOnClose = false;
 
   let modalBody;
 
   let dialog;
 
   function logKeys(e) {
-    console.log(`Key "${e.key}" was pressed`);
+    // console.log(`Key "${e.key}" was pressed`);
     if (e.key === 'Escape') {
       hide();
       window.removeEventListener('keydown', logKeys);
@@ -32,7 +33,7 @@
     }
     isOpen = true;
     dialog.showModal();
-    if (focusHelpOnClose) {
+    if (focusHelpOnClose || focusMyAccountOnClose) {
       window.addEventListener('keydown', logKeys);
     }
   };
@@ -52,6 +53,9 @@
 
     if (focusHelpOnClose) {
       document.getElementById('get-help').focus();
+    }
+    if (focusMyAccountOnClose) {
+      document.querySelector('#my-account a').focus();
     }
   };
 

--- a/src/js/components/Navbar/Navbar.stories.js
+++ b/src/js/components/Navbar/Navbar.stories.js
@@ -76,7 +76,7 @@ export const DesktopLoggedInResourceSharingRole = {
   ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const accountButton = canvas.getByLabelText('My account');
+    const accountButton = canvas.getByLabelText(/My Account/);
     await userEvent.click(accountButton);
   },
 };
@@ -94,7 +94,7 @@ export const DesktopLoggedInResourceSharingRoleActivated = {
   ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const accountButton = canvas.getByLabelText('My account');
+    const accountButton = canvas.getByLabelText(/My Account/);
     await userEvent.click(accountButton);
   },
 };
@@ -174,7 +174,7 @@ export const MobileLoggedInResourceSharingRole = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const mobileMenuButton = canvas.getByLabelText('Toggle navigation');
-    const accountButton = canvas.getByLabelText('My account');
+    const accountButton = canvas.getByLabelText(/My Account/);
     await userEvent.click(mobileMenuButton);
     await userEvent.click(accountButton);
   },
@@ -194,7 +194,7 @@ export const MobileLoggedInResourceSharingRoleActivated = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const mobileMenuButton = canvas.getByLabelText('Toggle navigation');
-    const accountButton = canvas.getByLabelText('My account' );
+    const accountButton = canvas.getByLabelText(/My Account/);
     await userEvent.click(mobileMenuButton);
     await userEvent.click(accountButton);
   },
@@ -237,7 +237,7 @@ export const MobileLoggedInMyAccountDropdown = {
     const canvas = within(canvasElement);
 
     const mobileMenuButton =  canvas.getByLabelText('Toggle navigation');
-    const myAccount =  canvas.getByLabelText('My account');
+    const myAccount =  canvas.getByLabelText(/My Account/);
 
     await userEvent.click(mobileMenuButton);
     await userEvent.click(myAccount);
@@ -265,7 +265,7 @@ export const MobileLoggedInResourceSharingRoleActivatedHasNotification = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const mobileMenuButton = canvas.getByLabelText('Toggle navigation');
-    const accountButton = canvas.getByLabelText('My account' );
+    const accountButton = canvas.getByLabelText(/My Account/);
     await userEvent.click(mobileMenuButton);
     await userEvent.click(accountButton);
   },

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -453,7 +453,6 @@
                           href="#"
                           role="button"
                           id="switch"
-                          aria-labelledby="switch role-heading role-active"
                           on:click={roleSwitchModal.show()}
                           ><i class="fa-solid fa-user-group fa-fw" aria-hidden="true" /><span class="needs-hover-state">
                             Switch Role

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -379,7 +379,7 @@
                 role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
-                aria-label="My account"
+                aria-labelledby="my-account-label role-heading role-active"
               >
                 <div class="d-flex justify-content-center align-items-center">
                   <span
@@ -392,8 +392,10 @@
                       <i class="fa-solid fa-user text-neutral-800" />
                     {/if}
                   </span>
-                  <span class="ms-3 d-xl-none">My Account</span><span class="visually-hidden d-none d-xl-block"
-                    >My Account</span
+                  <span id="my-account-label"
+                    ><span class="ms-3 d-xl-none">My Account</span><span class="visually-hidden d-none d-xl-block"
+                      >My Account</span
+                    ></span
                   >
                 </div>
               </a>
@@ -423,9 +425,11 @@
                         data-disabled={!hasNotification}
                         disabled={!hasNotification ? true : null}
                         on:click={notificationsModal.show()}
-                        ><i class="fa-solid fa-bell fa-fw" class:opacity-25={!hasNotification} /><span
-                          class="needs-hover-state"
+                        ><i
+                          class="fa-solid fa-bell fa-fw"
                           aria-hidden="true"
+                          class:opacity-25={!hasNotification}
+                        /><span class="needs-hover-state"
                           >Notifications {#if hasNotification}({notificationsManager.count()}){/if}</span
                         >
                       </button>

--- a/src/js/components/RoleSwitchModal/index.svelte
+++ b/src/js/components/RoleSwitchModal/index.svelte
@@ -34,7 +34,8 @@
     }
   });
 
-  function submit() {
+  function submit(event) {
+    event.preventDefault();
     loading = true;
     let params = new URLSearchParams();
     params.set('role', role);
@@ -69,6 +70,7 @@
           action="/cgi/ping/switch"
           method="POST"
           class="w-100 h-100 d-flex flex-column justify-content-between"
+          on:submit={submit}
         >
           <div class="roles d-flex flex-column h-100">
             <label
@@ -232,15 +234,10 @@
           <button class="btn btn-white border-0 py-2 px-3 m-0" name="action" value="cancel" on:click={() => hide()}
             >Cancel</button
           >
-          <button
-            class="btn btn-primary py-2 px-3 m-0"
-            type="submit"
-            form="ping-switch"
-            disabled={loading}
-            on:click={submit}
+          <button class="btn btn-primary py-2 px-3 m-0" type="submit" form="ping-switch" disabled={loading}
             >Submit{#if loading}
               <span class="spinner-border spinner-border-sm ms-2" role="status" aria-hidden="true"></span>
-              <span class="visually-hidden">Switching your role to {roleActivated ? 'Member' : roleLabel}</span
+              <span class="visually-hidden">Switching your role to {role === 'default' ? 'Member' : roleLabel}</span
               >{/if}</button
           >
         </div>

--- a/src/js/components/RoleSwitchModal/index.svelte
+++ b/src/js/components/RoleSwitchModal/index.svelte
@@ -56,7 +56,7 @@
 </script>
 
 <div class="switch-roles">
-  <Modal bind:this={modal} scrollable modalLarge fullscreenOnMobile>
+  <Modal bind:this={modal} scrollable modalLarge fullscreenOnMobile focusMyAccountOnClose>
     <svelte:fragment slot="title">
       <div class="align-items-center d-flex gap-2 py-2 settings-heading">
         <img {src} alt="" role="presentation" />

--- a/src/js/components/RoleSwitchModal/index.svelte
+++ b/src/js/components/RoleSwitchModal/index.svelte
@@ -6,6 +6,14 @@
   let switchableRole = Object.keys(HT.login_status.r)[0];
   let roleActivated = Object.values(HT.login_status.r)[0];
   let role = roleActivated ? switchableRole : 'default';
+
+  const switchableRolesLabels = {};
+  switchableRolesLabels['enhancedTextProxy'] = 'Accessible Text Request Service';
+  switchableRolesLabels['totalAccess'] = 'Collection Administration Access';
+  switchableRolesLabels['resourceSharing'] = 'Resource Sharing';
+
+  let roleLabel = switchableRolesLabels[switchableRole];
+
   let url = document.location.href;
   let modal;
   export let src = '/common/firebird/dist/hathitrust-icon-orange.svg';
@@ -110,13 +118,7 @@
                   >
                   <div class="d-flex flex-column gap-2">
                     <span id="switchable" class="form-check-label">
-                      {#if switchableRole === 'resourceSharing'}
-                        Resource Sharing
-                      {:else if switchableRole === 'totalAccess'}
-                        Collection Administration Access
-                      {:else if switchableRole === 'enhancedTextProxy'}
-                        Accessible Text Request Service (ATRS) Provider
-                      {/if} <span class="visually-hidden">For additional info read below</span>
+                      {roleLabel} <span class="visually-hidden">For additional info read below</span>
                     </span>
                     <div class="option--help">
                       {#if switchableRole === 'resourceSharing'}
@@ -227,7 +229,7 @@
     <svelte:fragment slot="footer">
       <div class="py-3 px-4 m-0">
         <div class="d-flex gap-3">
-          <button class="btn btn-white py-2 px-3 m-0" name="action" value="cancel" on:click={() => hide()}
+          <button class="btn btn-white border-0 py-2 px-3 m-0" name="action" value="cancel" on:click={() => hide()}
             >Cancel</button
           >
           <button
@@ -238,7 +240,8 @@
             on:click={submit}
             >Submit{#if loading}
               <span class="spinner-border spinner-border-sm ms-2" role="status" aria-hidden="true"></span>
-              <span class="visually-hidden">Loading...</span>{/if}</button
+              <span class="visually-hidden">Switching your role to {roleActivated ? 'Member' : roleLabel}</span
+              >{/if}</button
           >
         </div>
       </div>

--- a/src/js/components/RoleSwitchModal/index.svelte
+++ b/src/js/components/RoleSwitchModal/index.svelte
@@ -8,7 +8,7 @@
   let role = roleActivated ? switchableRole : 'default';
 
   const switchableRolesLabels = {};
-  switchableRolesLabels['enhancedTextProxy'] = 'Accessible Text Request Service';
+  switchableRolesLabels['enhancedTextProxy'] = 'Accessible Text Request Service (ATRS)';
   switchableRolesLabels['totalAccess'] = 'Collection Administration Access';
   switchableRolesLabels['resourceSharing'] = 'Resource Sharing';
 


### PR DESCRIPTION
The changes here are a11y fixes that @giramesh identified during testing of ETT-324 and ETT-347:
- fix the label for the notifications button 
- fix the modal "cancel" button style conflict in wordpress
- associate the “current role” elements with the “my account” button via aria-labelledby; remove the "current role" label from the "switch role" button
- add state change language to submit button icon label
- on modal close (either X button or Cancel button) via keyboard, return focus to navbar/My Account button

These fixes are so small, I'm not sure there's much to review. This is staged on dev-3 if you want to run through the log in and switch role process with your keyboard/screen reader, you could double check that the announcements make sense.

These fixes changed the markup in the navbar and probably broke playwright tests in page turner. I'll give those a check when updating firebird for pt.