### PR TITLE
ETT-1301 update "Featured Collections" link in navbar

### DIFF
--- a/src/assets/menuData.json
+++ b/src/assets/menuData.json
@@ -28,7 +28,7 @@
     },
     {
       "title": "Featured Collections",
-      "link": "https://babel.hathitrust.org/cgi/mb?colltype=featured"
+      "link": "https://babel.hathitrust.org/cgi/mb?a=listcs&colltype=featured"
     },
     {
       "title": "How to Search & Access",

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -288,7 +288,7 @@
               {#each menuData.collection as menuItem}
                 <li class="px-3">
                   {#if menuItem.title === 'Featured Collections'}
-                    <a class="dropdown-item px-0" href="//{HT.service_domain}/cgi/mb?colltype=featured"
+                    <a class="dropdown-item px-0" href="//{HT.service_domain}/cgi/mb?a=listcs&colltype=featured"
                       >{menuItem.title}</a
                     >
                   {:else}


### PR DESCRIPTION
- As noted in the ticket I'm jumping the gun on switching to ampersand as URL delimiter (see ETT-1149)
- Changed in two places -- it's hardcoded in index.svelte and appears to override the value in menuData.json
- Can I/Do I need to test this beyond "yup it changed" when I run inside `babel`?