### PR TITLE
ETT-1169: rearrange navbar markup for better a11y

### DIFF
--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -250,15 +250,13 @@
     <div class="collapse navbar-collapse justify-content-between" id="navbarNavDropdown">
       <ul class="navbar-nav menu-links">
         <li class="nav-item dropdown">
-          <a
+          <button
             class="nav-link dropdown-toggle d-flex flex-row justify-content-between align-items-center"
-            href="#"
-            role="button"
             data-bs-toggle="dropdown"
             aria-expanded="false"
           >
             <span>About</span>
-          </a>
+          </button>
           <div>
             <ul class="dropdown-menu">
               <div class="d-flex flex-column gap-4">
@@ -272,15 +270,13 @@
           </div>
         </li>
         <li class="nav-item dropdown">
-          <a
+          <button
             class="nav-link dropdown-toggle d-flex flex-row justify-content-between align-items-center"
-            href="#"
-            role="button"
             data-bs-toggle="dropdown"
             aria-expanded="false"
           >
             <span>The Collection</span>
-          </a>
+          </button>
           <ul class="dropdown-menu">
             <div class="d-flex flex-column gap-4">
               {#each menuData.collection as menuItem}
@@ -298,15 +294,13 @@
           </ul>
         </li>
         <li class="nav-item dropdown">
-          <a
+          <button
             class="nav-link dropdown-toggle d-flex flex-row justify-content-between align-items-center"
-            href="#"
-            role="button"
             data-bs-toggle="dropdown"
             aria-expanded="false"
           >
             <span>Member Libraries</span>
-          </a>
+          </button>
           <ul class="dropdown-menu">
             <div class="d-flex flex-column gap-4">
               {#each menuData.memberLibraries as menuItem}
@@ -321,15 +315,13 @@
           <a class="nav-link" href="//{HT.www_domain}/join/">Join</a>
         </li>
         <li class="nav-item dropdown">
-          <a
+          <button
             class="nav-link dropdown-toggle d-flex flex-row justify-content-between align-items-center"
-            href="#"
-            role="button"
             data-bs-toggle="dropdown"
             aria-expanded="false"
           >
             <span>News &amp; Events</span>
-          </a>
+          </button>
           <ul class="dropdown-menu">
             <div class="d-flex flex-column gap-4">
               {#each menuData.newsEvents as menuItem}
@@ -344,26 +336,22 @@
       <ul class="navbar-nav action-links">
         {#if searchState != 'none'}
           <li class="nav-item d-none d-xl-block">
-            <a
+            <button
               class="nav-link text-uppercase d-flex flex-row justify-content-between align-items-center"
               class:search-active={searchOpen}
-              href="#"
-              role="button"
               aria-expanded={searchOpen}
-              onclick={toggleSearch}>Search <i class="fa-solid fa-magnifying-glass fa-fw"></i></a
+              onclick={toggleSearch}>Search <i class="fa-solid fa-magnifying-glass fa-fw"></i></button
             >
           </li>
         {/if}
         <li class="nav-item dropdown">
-          <a
-            href="#"
-            role="button"
+          <button
             id="get-help"
             aria-expanded="false"
             class="nav-link dropdown-toggle text-uppercase d-flex flex-row justify-content-between align-items-center gap-2"
             data-bs-toggle="dropdown"
             ><span>Get Help</span>
-          </a>
+          </button>
           <ul class="dropdown-menu dropdown-menu-end p-0">
             <div class="d-flex flex-column gap-1 p-2">
               <li>
@@ -377,8 +365,7 @@
                 </a>
               </li>
               <li>
-                <a
-                  href="#"
+                <button
                   id="ask-a-question"
                   class="dropdown-item d-flex flex-row align-items-center gap-2"
                   onclick={() => openFeedback('questions')}
@@ -386,17 +373,16 @@
                   <i class="fa-solid fa-circle-question fa-fw text-neutral-500" aria-hidden="true"></i><span
                     >Ask a Question</span
                   >
-                </a>
+                </button>
               </li>
               <li>
-                <a
-                  href="#"
+                <button
                   id="report-a-problem"
                   class="dropdown-item d-flex flex-row align-items-center gap-2"
                   onclick={() => openFeedback(location)}
                 >
                   <i class="fa-solid fa-bug fa-fw text-neutral-500" aria-hidden="true"></i><span>Report a Problem</span>
-                </a>
+                </button>
               </li>
             </div>
           </ul>
@@ -404,9 +390,8 @@
         {#if userNavigation}
           {#if loggedIn}
             <li id="my-account" class="nav-item dropdown">
-              <a
+              <button
                 class="nav-link dropdown-toggle d-flex flex-row justify-content-between align-items-center text-black-hover text-black-focus"
-                href="#"
                 role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
@@ -429,7 +414,7 @@
                     ></span
                   >
                 </div>
-              </a>
+              </button>
               <ul class="dropdown-menu dropdown-menu-end p-0" class:accountDropdown={!hasSwitchableRoles}>
                 <div class="d-flex flex-column">
                   {#if hasSwitchableRoles}
@@ -475,17 +460,15 @@
                   <div class="p-2 gap-1 d-flex flex-column">
                     {#if hasSwitchableRoles}
                       <li>
-                        <a
+                        <button
                           class="dropdown-item d-flex flex-row gap-2 align-items-center switch-roles"
-                          href="#"
-                          role="button"
                           id="switch"
                           onclick={openRoleSwitchModal}
                           ><i class="fa-solid fa-user-group fa-fw" aria-hidden="true"></i><span
                             class="needs-hover-state"
                           >
                             Switch Role
-                          </span></a
+                          </span></button
                         >
                       </li>
                     {/if}
@@ -506,13 +489,11 @@
           {:else}
             <LoginFormModal {target} bind:this={loginModal} />
             <li class="nav-item">
-              <a
+              <button
                 id="log-in"
                 class="nav-link text-uppercase d-flex align-items-center gap-2"
-                href="#"
-                role="button"
                 data-testid="login-button"
-                onclick={openLogin}><i class="fa-solid fa-user fa-fw" aria-hidden="true"></i>Log In</a
+                onclick={openLogin}><i class="fa-solid fa-user fa-fw" aria-hidden="true"></i>Log In</button
               >
             </li>
           {/if}
@@ -581,7 +562,7 @@
     padding-right: 1rem;
     gap: 1.5rem;
   }
-  .navbar-nav.menu-links .nav-item a {
+  .navbar-nav.menu-links .nav-item button {
     @media (min-width: 1200px) {
       gap: 0.5rem;
     }
@@ -605,7 +586,7 @@
         }
       }
 
-      a {
+      button {
         @media (min-width: 1200px) {
           gap: 0.75rem;
         }
@@ -626,7 +607,7 @@
         border-radius: 0;
       }
     }
-    a.nav-link {
+    button.nav-link, a.nav-link {
       font-weight: 800;
       &.search-active {
         color: var(--color-primary-600);
@@ -708,6 +689,9 @@
       left: 27px;
     }
   }
+  button.dropdown-toggle {
+    border-radius: 6px;
+  }
   .dropdown-toggle::after {
     font-size: 1.1em;
   }
@@ -740,7 +724,7 @@
         padding-top: 0;
       }
     }
-    a {
+    a, button span {
       line-height: 1.125rem;
       letter-spacing: -0.00875rem;
       &:hover {

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -258,15 +258,15 @@
             <span>About</span>
           </button>
           <div>
-            <ul class="dropdown-menu">
-              <div class="d-flex flex-column gap-4">
+            <div class="dropdown-menu">
+              <ul class="d-flex flex-column gap-4 list-unstyled">
                 {#each menuData.about as menuItem}
                   <li class="px-3">
                     <a class="dropdown-item px-0" href="//{HT.www_domain}/{menuItem.link}">{menuItem.title}</a>
                   </li>
                 {/each}
-              </div>
-            </ul>
+              </ul>
+            </div>
           </div>
         </li>
         <li class="nav-item dropdown">
@@ -277,8 +277,8 @@
           >
             <span>The Collection</span>
           </button>
-          <ul class="dropdown-menu">
-            <div class="d-flex flex-column gap-4">
+          <div class="dropdown-menu">
+            <ul class="d-flex flex-column gap-4 list-unstyled">
               {#each menuData.collection as menuItem}
                 <li class="px-3">
                   {#if menuItem.title === 'Featured Collections'}
@@ -290,8 +290,8 @@
                   {/if}
                 </li>
               {/each}
-            </div>
-          </ul>
+            </ul>
+          </div>
         </li>
         <li class="nav-item dropdown">
           <button
@@ -301,15 +301,15 @@
           >
             <span>Member Libraries</span>
           </button>
-          <ul class="dropdown-menu">
-            <div class="d-flex flex-column gap-4">
+          <div class="dropdown-menu">
+            <ul class="d-flex flex-column gap-4 list-unstyled">
               {#each menuData.memberLibraries as menuItem}
                 <li class="px-3">
                   <a class="dropdown-item px-0" href="//{HT.www_domain}/{menuItem.link}">{menuItem.title}</a>
                 </li>
               {/each}
-            </div>
-          </ul>
+            </ul>
+          </div>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="//{HT.www_domain}/join/">Join</a>
@@ -322,15 +322,15 @@
           >
             <span>News &amp; Events</span>
           </button>
-          <ul class="dropdown-menu">
-            <div class="d-flex flex-column gap-4">
+          <div class="dropdown-menu">
+            <ul class="d-flex flex-column gap-4 list-unstyled">
               {#each menuData.newsEvents as menuItem}
                 <li class="px-3">
                   <a class="dropdown-item px-0" href="//{HT.www_domain}/{menuItem.link}">{menuItem.title}</a>
                 </li>
               {/each}
-            </div>
-          </ul>
+            </ul>
+          </div>
         </li>
       </ul>
       <ul class="navbar-nav action-links">
@@ -352,8 +352,8 @@
             data-bs-toggle="dropdown"
             ><span>Get Help</span>
           </button>
-          <ul class="dropdown-menu dropdown-menu-end p-0">
-            <div class="d-flex flex-column gap-1 p-2">
+          <div class="dropdown-menu dropdown-menu-end p-0">
+            <ul class="d-flex flex-column gap-1 p-2 list-unstyled">
               <li>
                 <a
                   href="https://hathitrust.atlassian.net/servicedesk/customer/portals"
@@ -384,15 +384,14 @@
                   <i class="fa-solid fa-bug fa-fw text-neutral-500" aria-hidden="true"></i><span>Report a Problem</span>
                 </button>
               </li>
-            </div>
-          </ul>
+            </ul>
+          </div>
         </li>
         {#if userNavigation}
           {#if loggedIn}
             <li id="my-account" class="nav-item dropdown">
               <button
                 class="nav-link dropdown-toggle d-flex flex-row justify-content-between align-items-center text-black-hover text-black-focus"
-                role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
                 aria-labelledby="my-account-label role-heading role-active"
@@ -415,8 +414,8 @@
                   >
                 </div>
               </button>
-              <ul class="dropdown-menu dropdown-menu-end p-0" class:accountDropdown={!hasSwitchableRoles}>
-                <div class="d-flex flex-column">
+              <div class="dropdown-menu dropdown-menu-end p-0" class:accountDropdown={!hasSwitchableRoles}>
+                <ul class="d-flex flex-column list-unstyled">
                   {#if hasSwitchableRoles}
                     <li class="d-flex p-3 current-role align-items-center border-bottom border-neutral-300">
                       <span
@@ -434,7 +433,8 @@
                       </div>
                     </li>
                   {/if}
-                  <div class="d-flex flex-column p-2 gap-1 border-bottom border-neutral-300">
+                  <li class="d-flex flex-column p-2 gap-1 border-bottom border-neutral-300">
+                  <ul class="list-unstyled">
                     <li>
                       <button
                         class="dropdown-item d-flex flex-row gap-2 align-items-center"
@@ -456,8 +456,10 @@
                         ></a
                       >
                     </li>
-                  </div>
-                  <div class="p-2 gap-1 d-flex flex-column">
+                    </ul>
+                  </li>
+                  <li class="p-2 gap-1 d-flex flex-column">
+                  <ul class="list-unstyled">
                     {#if hasSwitchableRoles}
                       <li>
                         <button
@@ -482,9 +484,10 @@
                         ></a
                       >
                     </li>
-                  </div>
-                </div>
-              </ul>
+                    </ul>
+                  </li>
+                </ul>
+              </div>
             </li>
           {:else}
             <LoginFormModal {target} bind:this={loginModal} />
@@ -567,6 +570,13 @@
       gap: 0.5rem;
     }
   }
+  .navbar-nav .nav-item {
+    display: flex;
+    flex-direction: column;
+    @media (min-width: 1200px) {
+      display: block;
+    }
+  }
   .navbar-nav.action-links {
     @media (min-width: 1200px) {
       padding-right: 1rem;
@@ -591,7 +601,7 @@
           gap: 0.75rem;
         }
       }
-      ul.dropdown-menu {
+      .dropdown-menu {
         background: var(--color-shades-0);
         a:hover,
         a:active {
@@ -607,7 +617,7 @@
         border-radius: 0;
       }
     }
-    button.nav-link, a.nav-link {
+    button.nav-link {
       font-weight: 800;
       &.search-active {
         color: var(--color-primary-600);
@@ -619,7 +629,7 @@
     i {
       color: var(--color-primary-600);
     }
-    #my-account ul.dropdown-menu li:not(.current-role) i {
+    #my-account .dropdown-menu li:not(.current-role) i {
       color: var(--color-neutral-500);
     }
     .needs-hover-state:hover {
@@ -656,10 +666,10 @@
   .role {
     gap: 0.125rem;
   }
-  #my-account a.nav-link div {
-    text-decoration: none;
-  }
-  #my-account a.switch-roles {
+  // #my-account a.nav-link div {
+  //   text-decoration: none;
+  // }
+  #my-account .switch-roles {
     max-width: 13rem;
     white-space: pre-wrap;
   }
@@ -700,7 +710,7 @@
     #my-account .dropdown-menu {
       width: 14rem;
     }
-    #my-account ul.accountDropdown {
+    #my-account .accountDropdown {
       width: 11rem;
     }
   }

--- a/src/js/components/Navbar/index.svelte
+++ b/src/js/components/Navbar/index.svelte
@@ -576,6 +576,9 @@
     @media (min-width: 1200px) {
       display: block;
     }
+    .nav-link:focus-visible {
+      z-index: 1003 !important;
+    }
   }
   .navbar-nav.action-links {
     @media (min-width: 1200px) {
@@ -666,9 +669,6 @@
   .role {
     gap: 0.125rem;
   }
-  // #my-account a.nav-link div {
-  //   text-decoration: none;
-  // }
   #my-account .switch-roles {
     max-width: 13rem;
     white-space: pre-wrap;
@@ -699,7 +699,7 @@
       left: 27px;
     }
   }
-  button.dropdown-toggle {
+  button.dropdown-toggle, button#log-in {
     border-radius: 6px;
   }
   .dropdown-toggle::after {


### PR DESCRIPTION
The navbar had some _creative_ markup that was not technically valid HTML. 

`<ul>` elements should only ever have `<li>` descendants, but I had sprinkled in some `<div>`s at some point to aid in styling. This PR rearranges the markup to ensure the correct hierarchy. I then had to fix some styles to reflect the changes in the markup.

I also took this opportunity to address some links that had empty `href` attributes that kept getting flagged by our automated accessibility tools. They were _technically_ fine since the links had `role="button"` but it took very little effort to make them actual `<button>` elements, so that's what I did. Goodbye, annoying warnings!

This is staged on dev-3, but there isn't really anything to see since nothing changed visually or functionally. Gayathri already approved the chromatic build, so this is more of a "check I didn't miss any small dumb mistakes" request. Thanks!