### PR TITLE
a11y: update search bar to use search element

### DIFF
--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -170,8 +170,8 @@
 </script>
 
 <div>
-  <search class="search-form-wrapper" bind:this={_root}>
-    <form onsubmit={_submitSearch} aria-label="Search HathiTrust">
+  <search class="search-form-wrapper" bind:this={_root} aria-label="Search HathiTrust">
+    <form onsubmit={_submitSearch}>
       <div id="searchbar-form" class="input-group d-flex">
         <div class="search-input">
           <input

--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -170,8 +170,8 @@
 </script>
 
 <div>
-  <div class="search-form-wrapper" bind:this={_root}>
-    <form onsubmit={_submitSearch} role="search" aria-label="Search HathiTrust">
+  <search class="search-form-wrapper" bind:this={_root}>
+    <form onsubmit={_submitSearch} aria-label="Search HathiTrust">
       <div id="searchbar-form" class="input-group d-flex">
         <div class="search-input">
           <input
@@ -246,7 +246,7 @@
         >
       </div>
     </div>
-  </div>
+  </search>
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
The `<search>` element became [baseline widely-available in April](https://web.dev/blog/baseline-digest-apr-2026#search_element). SiteImprov had an annoying error that the elements beneath the search bar (search hint, search help and advanced search links) were not included in a landmark region. Making the entire search bar a `<search>` element will clear up that error and benefit screenreader users.