### PR TITLE
ETT-1529: bugfix for clearing input when switching from collection to website search

### DIFF
--- a/src/js/components/SearchBar/SearchBar.stories.js
+++ b/src/js/components/SearchBar/SearchBar.stories.js
@@ -1,6 +1,6 @@
 import SearchBar from './index.svelte';
 import PingCallbackDecorator from '../../decorators/PingCallbackDecorator';
-import { userEvent, within } from 'storybook/test';
+import { userEvent, within, expect } from 'storybook/test';
 
 export default {
   title: 'Search Bar',
@@ -12,7 +12,6 @@ export default {
     }),
   ],
 };
-
 export const Mobile = {
   globals: {
     viewport: {
@@ -22,13 +21,26 @@ export const Mobile = {
   },
 };
 export const Desktop = {
-  args: {
-    modalOpen: false,
-  },
   globals: {
     viewport: {
       value: 'bsXl',
       isRotated: false,
     },
+  },
+};
+export const TypeThenChangeFields = {
+  globals: {
+    viewport: {
+      value: 'bsXl',
+      isRotated: false,
+    },
+  },
+  play: async ({ canvas, userEvent }) => {
+    await canvas.getByLabelText('Search using keywords').focus();
+    await userEvent.type(canvas.getByLabelText('Search using keywords'), 'elephant');
+    const whereToSearch = canvas.getByLabelText('Where do you want to search?');
+    await userEvent.selectOptions(whereToSearch, 'Collection');
+
+    expect(await canvas.getByLabelText('Search using keywords')).toHaveValue('elephant');
   },
 };

--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -108,7 +108,7 @@
     // find current configuration
     let _searchtypeValue = 'everything';
     let _selectValue = 'library';
-    let _inputValue = '';
+    let _inputValue = _input?.value ?? '';
     if (location && location.href) {
       let searchParams = new URLSearchParams(location.search.replace(/;/g, '&'));
 
@@ -147,7 +147,6 @@
         } else if (dropdownSelected == true && index == 'library') {
           _selectValue = 'library';
           index = 'library';
-          _inputValue = '';
         } else {
           _selectValue = 'website';
           index = 'website';

--- a/src/js/components/SearchBar/index.svelte
+++ b/src/js/components/SearchBar/index.svelte
@@ -103,14 +103,14 @@
   };
 
   $effect(() => {
+    if (!_searchtype || !_select || !_input) return;
+
     // find current configuration
     let _searchtypeValue = 'everything';
     let _selectValue = 'library';
     let _inputValue = '';
     if (location && location.href) {
       let searchParams = new URLSearchParams(location.search.replace(/;/g, '&'));
-
-      const isAdvancedSearch = searchParams.get('adv') == '1';
 
       if (isSiteBabel() || isWebsiteHome()) {
         _searchtypeValue = 'everything';


### PR DESCRIPTION
## The problem

On prod, if you start from the "website" search option, type in a keyword, then switch back to "collection" search, your search input gets erased. 

## The fix

Most of the search logic is inside the `$effect` block, and all the variables inside that block are reactive. When the dropdown select changes value (from "Website" to "Collection"), everything in the effect block runs, including setting the search input to a blank string. The fix ended up being very simple: check to make sure there isn't already a value in the input before resetting it to an empty string.

I also added a guard to the top of the `$effect` block. I was getting an error in storybook that some values weren't defined, so I added the check to make sure the UI was rendered before trying to do anything else.

## Testing

This is staged on dev-3: https://dev-3.www.hathitrust.org/ (please excuse the ACF Better Search warnings at the top of the page... this plugin was finally updated last week, and I will be updating the plugin soon!)

1. In the search bar, use the dropdown to switch from "Collection" search to "Website" search.
2. Switch back to "Collection." 
3. Your keywords will be the same!

I tested this in all of the places the search bar appears (wordpress, ls, mb, catalog, pt) and had no issues, but feel free to test as much as you want!

## Automated test

I added a storybook test that checks for this bug: https://dev-3.babel.hathitrust.org/common/firebird/dist/storybook/?path=/story/search-bar--type-then-change-fields&globals=viewport:bsLg