### PR TITLE
ETT-1134, 1136: a11y fixes for feedback form and results pagination

### DIFF
--- a/src/js/components/FeedbackFormBasic/index.svelte
+++ b/src/js/components/FeedbackFormBasic/index.svelte
@@ -147,7 +147,6 @@
       </label>
       <input
         aria-describedby="{id}-name-error"
-        type="name"
         class="form-control"
         id="{id}-name"
         name="name"

--- a/src/js/components/FeedbackFormCatalog/index.svelte
+++ b/src/js/components/FeedbackFormCatalog/index.svelte
@@ -146,7 +146,7 @@
   <form {onsubmit} class:hidden class="needs-validation mb-3" name="feedback" novalidate {id}>
     <div class="mb-3">
       <label for="name" class="form-label">Name <span class="required" aria-hidden="true">(required)</span></label>
-      <input type="name" class="form-control" id="name" autocomplete="name" name="name" required />
+      <input class="form-control" id="name" autocomplete="name" name="name" required />
       <div class="invalid-feedback">
         {#if nameError}
           <span>Error: Please provide your name.</span>

--- a/src/js/components/FeedbackFormContent/index.svelte
+++ b/src/js/components/FeedbackFormContent/index.svelte
@@ -151,15 +151,7 @@
   <form {onsubmit} class:hidden class="needs-validation mb-3" name="feedback" novalidate {id}>
     <div class="mb-3">
       <label for="name" class="form-label">Name <span class="required" aria-hidden="true">(required)</span></label>
-      <input
-        aria-describedby="name-error"
-        type="name"
-        autocomplete="name"
-        class="form-control"
-        id="name"
-        name="name"
-        required
-      />
+      <input aria-describedby="name-error" autocomplete="name" class="form-control" id="name" name="name" required />
       <div class="invalid-feedback" id="name-error">
         {#if nameError}<span>Error: Please provide your name.</span>{/if}
       </div>

--- a/src/js/components/ResultsPagination/index.svelte
+++ b/src/js/components/ResultsPagination/index.svelte
@@ -44,12 +44,14 @@
     <ul class="list-unstyled d-flex gap-2 m-0">
       <li>
         {#if !hasPreviousItem}
-          <span
+          <button
             aria-hidden="true"
+            aria-disabled="true"
             class="btn btn-outline-secondary disabled d-inline-flex align-items-center gap-1 text-decoration-none"
+            disabled
           >
             <i aria-hidden="true" class="fa-solid fa-chevron-left"></i><span>Previous</span>
-          </span>
+          </button>
         {:else}
           <a
             role={!hasPreviousItem ? 'link' : undefined}
@@ -61,12 +63,14 @@
       </li>
       <li>
         {#if !hasNextItem}
-          <span
+          <button
             aria-hidden="true"
+            aria-disabled="true"
             class="btn btn-outline-secondary disabled d-inline-flex align-items-center gap-1 text-decoration-none"
+            disabled
           >
             <span>Next</span><i aria-hidden="true" class="fa-solid fa-chevron-right"></i>
-          </span>
+          </button>
         {:else}
           <a
             role={!hasNextItem ? 'link' : undefined}

--- a/src/js/components/ResultsPagination/index.svelte
+++ b/src/js/components/ResultsPagination/index.svelte
@@ -45,7 +45,6 @@
       <li>
         {#if !hasPreviousItem}
           <button
-            aria-hidden="true"
             aria-disabled="true"
             class="btn btn-outline-secondary disabled d-inline-flex align-items-center gap-1 text-decoration-none"
             disabled
@@ -64,7 +63,6 @@
       <li>
         {#if !hasNextItem}
           <button
-            aria-hidden="true"
             aria-disabled="true"
             class="btn btn-outline-secondary disabled d-inline-flex align-items-center gap-1 text-decoration-none"
             disabled

--- a/src/js/components/ResultsPagination/index.svelte
+++ b/src/js/components/ResultsPagination/index.svelte
@@ -43,28 +43,38 @@
   <div>
     <ul class="list-unstyled d-flex gap-2 m-0">
       <li>
-        <a
-          aria-hidden={!hasPreviousItem}
-          aria-disabled={!hasPreviousItem}
-          role={!hasPreviousItem ? 'link' : undefined}
-          disabled={!hasPreviousItem}
-          class:disabled={!hasPreviousItem}
-          href={hasPreviousItem ? prevHref : undefined}
-          class="btn btn-outline-secondary d-inline-flex align-items-center gap-1 text-decoration-none"
-          ><i aria-hidden="true" class="fa-solid fa-chevron-left"></i><span>Previous</span></a
-        >
+        {#if !hasPreviousItem}
+          <span
+            aria-hidden="true"
+            class="btn btn-outline-secondary disabled d-inline-flex align-items-center gap-1 text-decoration-none"
+          >
+            <i aria-hidden="true" class="fa-solid fa-chevron-left"></i><span>Previous</span>
+          </span>
+        {:else}
+          <a
+            role={!hasPreviousItem ? 'link' : undefined}
+            href={hasPreviousItem ? prevHref : undefined}
+            class="btn btn-outline-secondary d-inline-flex align-items-center gap-1 text-decoration-none"
+            ><i aria-hidden="true" class="fa-solid fa-chevron-left"></i><span>Previous</span></a
+          >
+        {/if}
       </li>
       <li>
-        <a
-          aria-hidden={!hasNextItem}
-          aria-disabled={!hasNextItem}
-          role={!hasNextItem ? 'link' : undefined}
-          disabled={!hasNextItem}
-          class:disabled={!hasNextItem}
-          href={hasNextItem ? nextHref : undefined}
-          class="btn btn-outline-secondary d-inline-flex align-items-center gap-1 text-decoration-none"
-          ><span>Next</span><i aria-hidden="true" class="fa-solid fa-chevron-right"></i></a
-        >
+        {#if !hasNextItem}
+          <span
+            aria-hidden="true"
+            class="btn btn-outline-secondary disabled d-inline-flex align-items-center gap-1 text-decoration-none"
+          >
+            <span>Next</span><i aria-hidden="true" class="fa-solid fa-chevron-right"></i>
+          </span>
+        {:else}
+          <a
+            role={!hasNextItem ? 'link' : undefined}
+            href={hasNextItem ? nextHref : undefined}
+            class="btn btn-outline-secondary d-inline-flex align-items-center gap-1 text-decoration-none"
+            ><span>Next</span><i aria-hidden="true" class="fa-solid fa-chevron-right"></i></a
+          >
+        {/if}
       </li>
     </ul>
   </div>


### PR DESCRIPTION
These two tickets were small enough that I combined them in one PR.

## ETT-1134: Invalid `type` attribute in `<input>`

The feedback forms had an invalid `type="name"` (type of name doesn't exist), so I deleted it from all three versions of the form.

## ETT-1136: Links use `disabled` attribute

We've already fixed this issue in pt, so I did the same thing here. The issue is that when there is no "previous" or "next" page of results, the link (that looks like a button) sets a `disabled` state, but `<a>` elements can't have a `disabled` state. I added a conditional that used the same variables from the component and render a disabled button (no link) instead of the link when necessary.

Gayathri and I went back and forth on the best method to achieve this, and in the end we relied on [this article from CSS Tricks](https://css-tricks.com/making-disabled-buttons-more-inclusive/#final-thoughts) (knowing that the `disabled` attribute can be problematic but is the best use case for pagination) and copied the example from [theWCAG's pagination documentation](https://www.thewcag.com/examples/pagination). 

## To test

Staged on dev-3: https://dev-3.babel.hathitrust.org/cgi/ls?q1=elephant;field1=ocr;a=srchls;ft=ft;lmt=ft 

You can take a look at the feedback form markup if you want, but it didn't change the UI in any way.

The results pagination also doesn't really look different, but I guess you could go over there and try tabbing around and make sure it's not broken.

The storybook tests pass and I tested this on dev-3.